### PR TITLE
Add unified response format

### DIFF
--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -1,6 +1,33 @@
 from core import response_proxy, say_proxy
 import core.plugin_instance as plugin_instance
+import os
 import traceback
+
+TELEGRAM_STICKER_SET = os.getenv("TELEGRAM_STICKERS", "RekkuRetroDECKMascot")
+
+async def send_rekku_sticker(bot, chat_id, emoji: str, reply_to_message_id=None):
+    """Send a sticker matching ``emoji`` from ``TELEGRAM_STICKER_SET``.
+
+    Falls back to sending the raw emoji if no sticker is found or on error.
+    """
+    try:
+        sticker_set = await bot.get_sticker_set(TELEGRAM_STICKER_SET)
+        for sticker in sticker_set.stickers:
+            if sticker.emoji == emoji:
+                await bot.send_sticker(
+                    chat_id=chat_id,
+                    sticker=sticker.file_id,
+                    reply_to_message_id=reply_to_message_id,
+                )
+                return
+    except Exception as e:
+        print(f"[ERROR] Failed to load sticker set '{TELEGRAM_STICKER_SET}': {e}")
+
+    await bot.send_message(
+        chat_id=chat_id,
+        text=emoji,
+        reply_to_message_id=reply_to_message_id,
+    )
 
 async def send_content(bot, chat_id, message, content_type, reply_to_message_id=None):
     print(f"[DEBUG] Invio contenuto: {content_type}, reply_to={reply_to_message_id}")
@@ -150,5 +177,7 @@ def extract_response_target(message, user_id):
 __all__ = [
     "send_content",
     "detect_media_type",
-    "extract_response_target"
+    "extract_response_target",
+    "send_rekku_sticker",
+    "TELEGRAM_STICKER_SET",
 ]

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -4,22 +4,27 @@ import traceback
 import os
 
 # Sticker set used for custom Rekku emoji
-TELEGRAM_STICKER_SET = os.getenv("TELEGRAM_STICKERS", "RekkuRetroDECKMascot")
+TELEGRAM_STICKERS = os.getenv("TELEGRAM_STICKERS", "RekkuRetroDECKMascot")
 
 async def send_rekku_sticker(bot, chat_id, emoji: str, reply_to_message_id=None):
     """Send a sticker from the configured set matching the given emoji."""
+
+    print(f"[DEBUG/sticker] Searching for emoji '{emoji}' in set '{TELEGRAM_STICKERS}'")
     try:
-        sticker_set = await bot.get_sticker_set(TELEGRAM_STICKER_SET)
+        sticker_set = await bot.get_sticker_set(TELEGRAM_STICKERS)
+        print(f"[DEBUG/sticker] Loaded {len(sticker_set.stickers)} stickers")
         for sticker in sticker_set.stickers:
             if sticker.emoji == emoji:
+                print(f"[DEBUG/sticker] Found match: {sticker.file_id}")
                 await bot.send_sticker(
                     chat_id=chat_id,
                     sticker=sticker.file_id,
                     reply_to_message_id=reply_to_message_id,
                 )
                 return
+        print(f"[DEBUG/sticker] No sticker match for '{emoji}'")
     except Exception as e:
-        print(f"[ERROR] Failed to load sticker set '{TELEGRAM_STICKER_SET}': {e}")
+        print(f"[ERROR/sticker] Failed to load sticker set: {e}")
 
     # Fallback: send the raw emoji as plain text
     try:
@@ -29,7 +34,7 @@ async def send_rekku_sticker(bot, chat_id, emoji: str, reply_to_message_id=None)
             reply_to_message_id=reply_to_message_id,
         )
     except Exception as e:
-        print(f"[ERROR] Fallback text send failed for emoji '{emoji}': {e}")
+        print(f"[ERROR/sticker] Fallback text send failed for emoji '{emoji}': {e}")
 
 async def send_content(bot, chat_id, message, content_type, reply_to_message_id=None):
     print(f"[DEBUG] Invio contenuto: {content_type}, reply_to={reply_to_message_id}")

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -1,17 +1,35 @@
 from core import response_proxy, say_proxy
 import core.plugin_instance as plugin_instance
 import traceback
+import os
+
+# Sticker set used for custom Rekku emoji
+TELEGRAM_STICKER_SET = os.getenv("TELEGRAM_STICKERS", "RekkuRetroDECKMascot")
 
 async def send_rekku_sticker(bot, chat_id, emoji: str, reply_to_message_id=None):
-    """Send a sticker by emoji using Telegram's built-in mapping."""
+    """Send a sticker from the configured set matching the given emoji."""
     try:
-        await bot.send_sticker(
+        sticker_set = await bot.get_sticker_set(TELEGRAM_STICKER_SET)
+        for sticker in sticker_set.stickers:
+            if sticker.emoji == emoji:
+                await bot.send_sticker(
+                    chat_id=chat_id,
+                    sticker=sticker.file_id,
+                    reply_to_message_id=reply_to_message_id,
+                )
+                return
+    except Exception as e:
+        print(f"[ERROR] Failed to load sticker set '{TELEGRAM_STICKER_SET}': {e}")
+
+    # Fallback: send the raw emoji as plain text
+    try:
+        await bot.send_message(
             chat_id=chat_id,
-            sticker=emoji,
+            text=emoji,
             reply_to_message_id=reply_to_message_id,
         )
     except Exception as e:
-        print(f"[ERROR] Failed to send sticker for emoji '{emoji}': {e}")
+        print(f"[ERROR] Fallback text send failed for emoji '{emoji}': {e}")
 
 async def send_content(bot, chat_id, message, content_type, reply_to_message_id=None):
     print(f"[DEBUG] Invio contenuto: {content_type}, reply_to={reply_to_message_id}")

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -1,33 +1,17 @@
 from core import response_proxy, say_proxy
 import core.plugin_instance as plugin_instance
-import os
 import traceback
 
-TELEGRAM_STICKER_SET = os.getenv("TELEGRAM_STICKERS", "RekkuRetroDECKMascot")
-
 async def send_rekku_sticker(bot, chat_id, emoji: str, reply_to_message_id=None):
-    """Send a sticker matching ``emoji`` from ``TELEGRAM_STICKER_SET``.
-
-    Falls back to sending the raw emoji if no sticker is found or on error.
-    """
+    """Send a sticker by emoji using Telegram's built-in mapping."""
     try:
-        sticker_set = await bot.get_sticker_set(TELEGRAM_STICKER_SET)
-        for sticker in sticker_set.stickers:
-            if sticker.emoji == emoji:
-                await bot.send_sticker(
-                    chat_id=chat_id,
-                    sticker=sticker.file_id,
-                    reply_to_message_id=reply_to_message_id,
-                )
-                return
+        await bot.send_sticker(
+            chat_id=chat_id,
+            sticker=emoji,
+            reply_to_message_id=reply_to_message_id,
+        )
     except Exception as e:
-        print(f"[ERROR] Failed to load sticker set '{TELEGRAM_STICKER_SET}': {e}")
-
-    await bot.send_message(
-        chat_id=chat_id,
-        text=emoji,
-        reply_to_message_id=reply_to_message_id,
-    )
+        print(f"[ERROR] Failed to send sticker for emoji '{emoji}': {e}")
 
 async def send_content(bot, chat_id, message, content_type, reply_to_message_id=None):
     print(f"[DEBUG] Invio contenuto: {content_type}, reply_to={reply_to_message_id}")
@@ -179,5 +163,4 @@ __all__ = [
     "detect_media_type",
     "extract_response_target",
     "send_rekku_sticker",
-    "TELEGRAM_STICKER_SET",
 ]

--- a/core/response_format.py
+++ b/core/response_format.py
@@ -1,0 +1,13 @@
+"""Utilities for standardized assistant responses."""
+
+from typing import Dict
+
+
+def text_response(content: str) -> Dict[str, str]:
+    """Return a text reply structure."""
+    return {"type": "text", "content": content}
+
+
+def sticker_response(emoji: str) -> Dict[str, str]:
+    """Return a sticker reply structure using an emoji as identifier."""
+    return {"type": "sticker", "emoji": emoji}

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -189,7 +189,30 @@ async def handle_incoming_response(update: Update, context: ContextTypes.DEFAULT
     content_type = target["type"]
 
     print(f"[DEBUG] Invio media_type={content_type} to chat_id={chat_id}, reply_to={reply_to}")
-    success, feedback = await send_content(context.bot, chat_id, message, content_type, reply_to)
+
+    # Gestione speciale per sticker: rimpiazza set Telegram predefiniti
+    if content_type == "sticker" and message.sticker:
+        set_name = message.sticker.set_name or ""
+        print(f"[DEBUG] Sticker set_name={set_name}")
+
+        if set_name.startswith("AnimatedEmoji"):
+            emoji = message.sticker.emoji or ""
+            print(f"[DEBUG] Mapping built-in sticker to custom set via emoji '{emoji}'")
+            await send_rekku_sticker(
+                context.bot,
+                chat_id,
+                emoji,
+                reply_to_message_id=reply_to,
+            )
+            success, feedback = True, "\u2705 Contenuto inviato con successo."
+        else:
+            success, feedback = await send_content(
+                context.bot, chat_id, message, content_type, reply_to
+            )
+    else:
+        success, feedback = await send_content(
+            context.bot, chat_id, message, content_type, reply_to
+        )
 
     await message.reply_text(feedback)
 

--- a/llm_engines/manual.py
+++ b/llm_engines/manual.py
@@ -5,7 +5,6 @@ from core.config import OWNER_ID
 from core.ai_plugin_base import AIPluginBase
 import json
 from telegram.constants import ParseMode
-from core.response_format import text_response
 
 class ManualAIPlugin(AIPluginBase):
 
@@ -47,7 +46,8 @@ class ManualAIPlugin(AIPluginBase):
             print(f"[DEBUG/manual] Invio da /say: chat_id={target_chat}")
             await bot.send_message(chat_id=target_chat, text=text)
             say_proxy.clear(user_id)
-            return text_response("📝 Messaggio inviato dal trainer.")
+            print("[DEBUG/manual] Messaggio inviato tramite /say")
+            return
 
         # === Invia prompt JSON al trainer (OWNER_ID) ===
         import json
@@ -75,7 +75,7 @@ class ManualAIPlugin(AIPluginBase):
         )
         self.track_message(sent.message_id, message.chat_id, message.message_id)
         print(f"[DEBUG/manual] Messaggio inoltrato e tracciato")
-        return text_response("⌛ In attesa di risposta manuale.")
+        return
 
     async def generate_response(self, messages):
         """Manual mode should not generate a reply automatically."""

--- a/llm_engines/manual.py
+++ b/llm_engines/manual.py
@@ -78,8 +78,9 @@ class ManualAIPlugin(AIPluginBase):
         return text_response("⌛ In attesa di risposta manuale.")
 
     async def generate_response(self, messages):
-        """Nel caso manuale, la risposta non viene generata automaticamente."""
-        return "\U0001f570\ufe0f Risposta in attesa di input manuale."
+        """Manual mode should not generate a reply automatically."""
+        print("[DEBUG/manual] \u26a0\ufe0f generate_response() called unexpectedly in manual mode.")
+        return ""
 
 
 PLUGIN_CLASS = ManualAIPlugin

--- a/llm_engines/manual.py
+++ b/llm_engines/manual.py
@@ -5,6 +5,7 @@ from core.config import OWNER_ID
 from core.ai_plugin_base import AIPluginBase
 import json
 from telegram.constants import ParseMode
+from core.response_format import text_response
 
 class ManualAIPlugin(AIPluginBase):
 
@@ -46,7 +47,7 @@ class ManualAIPlugin(AIPluginBase):
             print(f"[DEBUG/manual] Invio da /say: chat_id={target_chat}")
             await bot.send_message(chat_id=target_chat, text=text)
             say_proxy.clear(user_id)
-            return
+            return text_response("📝 Messaggio inviato dal trainer.")
 
         # === Invia prompt JSON al trainer (OWNER_ID) ===
         import json
@@ -74,6 +75,7 @@ class ManualAIPlugin(AIPluginBase):
         )
         self.track_message(sent.message_id, message.chat_id, message.message_id)
         print(f"[DEBUG/manual] Messaggio inoltrato e tracciato")
+        return text_response("⌛ In attesa di risposta manuale.")
 
     async def generate_response(self, messages):
         """Nel caso manuale, la risposta non viene generata automaticamente."""

--- a/llm_engines/openai_chatgpt.py
+++ b/llm_engines/openai_chatgpt.py
@@ -4,6 +4,7 @@ from core.ai_plugin_base import AIPluginBase
 import json
 import openai  # Assicurati che sia installato
 from core.config import get_user_api_key
+from core.response_format import text_response, sticker_response
 
 class OpenAIPlugin(AIPluginBase):
 
@@ -46,22 +47,23 @@ class OpenAIPlugin(AIPluginBase):
         self.reply_map.pop(trainer_message_id, None)
 
     async def handle_incoming_message(self, bot, message, prompt):
+        """Generate a reply and return it using the unified format."""
         from core.notifier import notify_owner
 
         notify_owner("🚨 Sto generando la risposta...")
 
         try:
-            response = await self.generate_response(prompt)
+            response_text = await self.generate_response(prompt)
 
             if bot and message:
                 print(f"[DEBUG/openai] Invio risposta a chat_id={message.chat_id}")
                 await bot.send_message(
                     chat_id=message.chat_id,
-                    text=response,
+                    text=response_text,
                     reply_to_message_id=message.message_id
                 )
 
-            return response
+            return text_response(response_text)
 
         except Exception as e:
             print(f"[ERROR/OpenAI] Errore durante la risposta: {e}")
@@ -72,7 +74,7 @@ class OpenAIPlugin(AIPluginBase):
                     chat_id=message.chat_id,
                     text="⚠️ Errore nella risposta LLM."
                 )
-            return "⚠️ Errore durante la generazione della risposta."
+            return text_response("⚠️ Errore durante la generazione della risposta.")
 
     async def generate_response(self, prompt):
         from core.config import get_user_api_key


### PR DESCRIPTION
## Summary
- provide `text_response` and `sticker_response` helpers for a uniform reply structure
- return these dictionaries from the OpenAI and Manual plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a540ce8883289812f836f5d2b84b