### PR TITLE
Add persistent terminal plugin

### DIFF
--- a/core/plugin_base.py
+++ b/core/plugin_base.py
@@ -1,0 +1,19 @@
+# core/plugin_base.py
+
+class PluginBase:
+    """Base class for non-LLM plugins."""
+
+    def __init__(self, config=None):
+        self.config = config or {}
+
+    def start(self):
+        """Optional initialization logic."""
+        pass
+
+    def stop(self):
+        """Optional teardown logic."""
+        pass
+
+    def get_metadata(self) -> dict:
+        """Return plugin metadata such as name, description and version."""
+        raise NotImplementedError("get_metadata must be implemented by the plugin")

--- a/llm_engines/terminal_plugin.py
+++ b/llm_engines/terminal_plugin.py
@@ -1,0 +1,94 @@
+# llm_engines/terminal_plugin.py
+
+import asyncio
+from core.ai_plugin_base import AIPluginBase
+from telegram.constants import ParseMode
+
+
+class TerminalPlugin(AIPluginBase):
+    """Plugin providing access to a persistent terminal session."""
+
+    def __init__(self, notify_fn=None):
+        self.process = None
+        self.notify_fn = notify_fn
+
+    async def _ensure_process(self):
+        """Ensure the background shell is running."""
+        if self.process is None or self.process.returncode is not None:
+            self.process = await asyncio.create_subprocess_shell(
+                "/bin/bash",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            print("[DEBUG/terminal] Shell subprocess started")
+
+    async def _send_command(self, cmd: str) -> str:
+        """Send ``cmd`` to the shell and return its output."""
+        await self._ensure_process()
+
+        sentinel = "__END__REKKU__"
+        full_cmd = f"{cmd}; echo {sentinel}\n"
+
+        try:
+            self.process.stdin.write(full_cmd.encode())
+            await self.process.stdin.drain()
+        except Exception as e:
+            print(f"[ERROR/terminal] Failed to write to shell: {e}")
+            self.process = None
+            return "⚠️ Unable to send command to shell."
+
+        output_lines = []
+        try:
+            while True:
+                line = await asyncio.wait_for(
+                    self.process.stdout.readline(), timeout=10.0
+                )
+                if not line:
+                    self.process = None
+                    return "⚠️ Terminal closed unexpectedly."
+                decoded = line.decode()
+                if decoded.rstrip() == sentinel:
+                    break
+                output_lines.append(decoded)
+        except asyncio.TimeoutError:
+            return "⚠️ Command timeout."
+
+        return "".join(output_lines).strip()
+
+    async def handle_incoming_message(self, bot, message, prompt):
+        cmd = (
+            prompt.get("action", {}).get("input")
+            or prompt.get("message", {}).get("text", "")
+        )
+        print(f"[DEBUG/terminal] Executing: {cmd}")
+        output = await self._send_command(cmd)
+
+        if bot and message:
+            truncated = output
+            if len(truncated) > 4000:
+                truncated = truncated[:4000] + "\n..."
+            await bot.send_message(
+                chat_id=message.chat_id,
+                text=f"```\n{truncated}\n```" if truncated else "(no output)",
+                parse_mode=ParseMode.MARKDOWN,
+                reply_to_message_id=message.message_id,
+            )
+
+        return output
+
+    async def generate_response(self, messages):
+        command = "\n".join(messages)
+        return await self._send_command(command)
+
+    def get_supported_actions(self):
+        return ["terminal"]
+
+    def get_target(self, trainer_message_id):
+        return None
+
+    def clear(self, trainer_message_id):
+        pass
+
+
+PLUGIN_CLASS = TerminalPlugin

--- a/plugin_loader.py
+++ b/plugin_loader.py
@@ -1,0 +1,76 @@
+# plugin_loader.py
+"""Dynamic loader for Rekku's optional plugins."""
+
+import importlib
+import json
+import os
+from typing import Dict
+
+from core.plugin_base import PluginBase
+
+PLUGIN_REGISTRY: Dict[str, PluginBase] = {}
+
+
+def _discover_plugins(path: str = "plugins") -> list[str]:
+    """Return a list of plugin package names found in the given directory."""
+    plugins = []
+    if not os.path.isdir(path):
+        return plugins
+    for entry in os.scandir(path):
+        if entry.is_dir() and os.path.isfile(os.path.join(entry.path, "__init__.py")):
+            plugins.append(entry.name)
+    return plugins
+
+
+def load_plugins(path: str = "plugins") -> Dict[str, PluginBase]:
+    """Import and initialize all plugins under the given path."""
+    for name in _discover_plugins(path):
+        module_name = f"{path.replace(os.sep, '.')}" + f".{name}"
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as e:
+            print(f"[plugin_loader] Failed to import {module_name}: {e}")
+            continue
+
+        plugin_cls = getattr(module, "PLUGIN_CLASS", None)
+        if plugin_cls is None:
+            print(f"[plugin_loader] {name} missing PLUGIN_CLASS, skipping")
+            continue
+
+        config = {}
+        cfg_path = os.path.join(path, name, "config.json")
+        if os.path.isfile(cfg_path):
+            try:
+                with open(cfg_path, "r", encoding="utf-8") as f:
+                    config = json.load(f)
+            except Exception as e:
+                print(f"[plugin_loader] Error reading config for {name}: {e}")
+
+        try:
+            plugin = plugin_cls(config=config)
+        except TypeError:
+            plugin = plugin_cls()
+
+        try:
+            plugin.start()
+        except Exception as e:
+            print(f"[plugin_loader] Error starting {name}: {e}")
+
+        PLUGIN_REGISTRY[name] = plugin
+
+    return PLUGIN_REGISTRY
+
+
+def get_plugin(name: str) -> PluginBase | None:
+    """Return a plugin instance by name."""
+    return PLUGIN_REGISTRY.get(name)
+
+
+def stop_plugins() -> None:
+    """Call stop() on all loaded plugins."""
+    for plugin in PLUGIN_REGISTRY.values():
+        try:
+            plugin.stop()
+        except Exception as e:
+            print(f"[plugin_loader] Error stopping plugin: {e}")
+    PLUGIN_REGISTRY.clear()

--- a/plugins/example_plugin/__init__.py
+++ b/plugins/example_plugin/__init__.py
@@ -1,0 +1,21 @@
+from core.plugin_base import PluginBase
+
+
+class ExamplePlugin(PluginBase):
+    """A sample plugin used for demonstration."""
+
+    def start(self):
+        print("[example_plugin] started")
+
+    def stop(self):
+        print("[example_plugin] stopped")
+
+    def get_metadata(self) -> dict:
+        return {
+            "name": "ExamplePlugin",
+            "description": "Sample plugin for the Rekku project",
+            "version": "0.1",
+        }
+
+
+PLUGIN_CLASS = ExamplePlugin


### PR DESCRIPTION
## Summary
- add a new TerminalPlugin for executing shell commands via a persistent subprocess
- implement a generic plugin system with a PluginBase, loader and example
- refine terminal plugin with persistent shell

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b469e82f483288b15b83cc08634a7