### PR TITLE
Add chromedriver-autoinstaller support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 # Python venv
 RUN python3 -m venv /app/venv && \
     /app/venv/bin/pip install --no-cache-dir --upgrade pip setuptools && \
-    /app/venv/bin/pip install --no-cache-dir -r /app/requirements.txt
+    /app/venv/bin/pip install --no-cache-dir -r requirements.txt
 
 # ENV
 ENV PYTHONPATH=/app \

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -1,4 +1,10 @@
-import chromedriver_autoinstaller
+try:
+    import chromedriver_autoinstaller
+except ImportError as e:
+    print(
+        "[ERROR] chromedriver_autoinstaller not installed. Please run 'pip install chromedriver-autoinstaller'"
+    )
+    raise
 import undetected_chromedriver as uc
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
@@ -214,6 +220,10 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                 self.driver = _get_driver()
                 # Ensure the right ChromeDriver is available
                 chromedriver_autoinstaller.install()
+                print(
+                    "[DEBUG] chromedriver_autoinstaller installed ChromeDriver for",
+                    chromedriver_autoinstaller.get_chrome_version(),
+                )
             except Exception as e:
                 _notify_gui(f"❌ Errore Selenium: {e}. Apri")
                 raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ undetected-chromedriver
 webdriver-manager
 setuptools
 pytz
+chromedriver-autoinstaller>=0.7.1


### PR DESCRIPTION
## Summary
- add chromedriver-autoinstaller to requirements
- install requirements inside Docker build
- handle missing chromedriver_autoinstaller import gracefully
- log installed ChromeDriver version after initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7c6693388328a1f280e79f926a9f