### PR TITLE
Fix Selenium worker startup

### DIFF
--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -71,11 +71,14 @@ def load_plugin(name: str, notify_fn=None):
                     loop = None
                 if loop and loop.is_running():
                     loop.create_task(start_fn())
+                    log_debug("[plugin] Plugin start executed on running loop.")
                 else:
-                    asyncio.run(start_fn())
+                    log_debug(
+                        "[plugin] No running loop; plugin start will be invoked later."
+                    )
             else:
                 start_fn()
-            log_debug("[plugin] Plugin start executed.")
+                log_debug("[plugin] Plugin start executed.")
         except Exception as e:
             log_error(f"[plugin] Error during plugin start: {e}", e)
 

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -673,6 +673,18 @@ def start_bot():
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()
 
+    # 🚀 Now that the loop is running, ensure plugin worker is started
+    plugin_obj = plugin_instance.get_plugin()
+    if plugin_obj and hasattr(plugin_obj, "start"):
+        try:
+            if asyncio.iscoroutinefunction(plugin_obj.start):
+                app.create_task(plugin_obj.start())
+            else:
+                plugin_obj.start()
+            log_debug("[plugin] Plugin start scheduled from start_bot.")
+        except Exception as e:
+            log_error(f"[plugin] Error starting plugin in start_bot: {e}", e)
+
     app.add_handler(CommandHandler("help", help_command))
     app.add_handler(CommandHandler("block", block_user))
     app.add_handler(CommandHandler("block_list", block_list))


### PR DESCRIPTION
## Summary
- enhance logging and reliability of `SeleniumChatGPTPlugin`
- only start plugins when a running event loop exists
- start Selenium plugin worker after telegram loop creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68711baefb1083289b026ddf42cea3eb