### PR TITLE
Add JSON action handling modules

### DIFF
--- a/core/actions_loader.py
+++ b/core/actions_loader.py
@@ -1,0 +1,33 @@
+import glob
+import importlib
+import os
+from core.logging_utils import log_debug, log_error
+
+
+def load_available_actions() -> list:
+    """Scan plugins for supported actions definitions."""
+    actions: list = []
+
+    for path in glob.glob(os.path.join("plugins", "**", "*.py"), recursive=True):
+        module_name = os.path.relpath(path, ".")[:-3].replace(os.sep, ".")
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as e:
+            log_error(f"[actions_loader] Failed to import {module_name}: {e}")
+            continue
+
+        if hasattr(module, "get_supported_actions"):
+            try:
+                plugin_actions = module.get_supported_actions()
+                if isinstance(plugin_actions, list):
+                    actions.extend(plugin_actions)
+                else:
+                    log_debug(
+                        f"[actions_loader] {module_name}.get_supported_actions returned non-list"
+                    )
+            except Exception as e:
+                log_error(
+                    f"[actions_loader] Error calling {module_name}.get_supported_actions: {e}"
+                )
+    log_debug(f"[actions_loader] Loaded actions: {actions}")
+    return actions

--- a/core/validate_action.py
+++ b/core/validate_action.py
@@ -1,0 +1,37 @@
+from typing import List, Dict
+from core.logging_utils import log_debug
+
+
+def validate_action(output_json: Dict) -> List[str]:
+    """Validate LLM JSON output describing actions.
+
+    Returns a list of error strings. Empty list means valid.
+    """
+    errors: List[str] = []
+
+    actions = output_json.get("actions")
+    if not isinstance(actions, list):
+        errors.append("'actions' must be a list")
+        return errors
+
+    for idx, action in enumerate(actions):
+        if not isinstance(action, dict):
+            errors.append(f"Action {idx} must be a dict")
+            continue
+        if list(action.keys()) != ["message"]:
+            errors.append(f"Action {idx} must contain only 'message'")
+            continue
+        message = action.get("message")
+        if not isinstance(message, dict):
+            errors.append(f"Action {idx} -> 'message' must be a dict")
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            errors.append(f"Action {idx} -> message.content must be a non-empty string")
+        target = message.get("target")
+        if not isinstance(target, str) or not target.startswith("Telegram/"):
+            errors.append(
+                f"Action {idx} -> message.target must be a string starting with 'Telegram/'"
+            )
+    log_debug(f"[validate_action] errors: {errors}")
+    return errors

--- a/tests/test_json_action_system.py
+++ b/tests/test_json_action_system.py
@@ -1,0 +1,43 @@
+import asyncio
+from types import SimpleNamespace
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.validate_action import validate_action
+from core.action_parser import parse_actions
+
+class FakeBot:
+    def __init__(self):
+        self.calls = []
+
+    async def send_message(self, chat_id, text, reply_to_message_id=None):
+        self.calls.append({
+            "chat_id": chat_id,
+            "text": text,
+            "reply_to_message_id": reply_to_message_id,
+        })
+
+
+def make_message():
+    return SimpleNamespace(message_id=42, from_user=SimpleNamespace(id=1, username="tester"))
+
+
+def test_validate_action_valid():
+    data = {"actions": [{"message": {"content": "hi", "target": "Telegram/123"}}]}
+    assert validate_action(data) == []
+
+
+def test_validate_action_invalid():
+    data = {"actions": [{"message": {"content": "", "target": "User/1"}}]}
+    errors = validate_action(data)
+    assert errors and any("Telegram/" in e or "non-empty" in e for e in errors)
+
+
+def test_parse_actions_sends_message():
+    bot = FakeBot()
+    msg = make_message()
+    data = {"actions": [{"message": {"content": "hello", "target": "Telegram/99"}}]}
+    asyncio.run(parse_actions(data, bot, msg))
+    assert bot.calls == [{"chat_id": "99", "text": "hello", "reply_to_message_id": 42}]


### PR DESCRIPTION
## Summary
- implement new JSON `parse_actions` in `action_parser`
- add stricter `validate_action` for LLM output
- add `actions_loader` to gather action descriptions from plugins
- enrich JSON prompt with available actions and interface instructions
- add tests for JSON action validation and parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a3def5f88328ba7058e19bc03ac8