### PR TITLE
Fix/broken chat

### DIFF
--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -330,21 +330,21 @@ def _open_new_chat(driver) -> None:
         # First, try to click the new chat button if it's visible
         try:
             btn = WebDriverWait(driver, 2).until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, "a[data-testid='new-chat-button']"))
+                EC.element_to_be_clickable((By.CSS_SELECTOR, "a[data-testid='create-new-chat-button']"))
             )
             btn.click()
-            log_debug("[selenium] Clicked new-chat-button")
+            log_debug("[selenium] Clicked create-new-chat-button")
             return
         except TimeoutException:
             log_debug("[selenium] New chat button not visible, navigating to home")
-            
+
         # If not visible, go to the home page and then click
         driver.get("https://chat.openai.com")
         btn = WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, "a[data-testid='new-chat-button']"))
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "a[data-testid='create-new-chat-button']"))
         )
         btn.click()
-        log_debug("[selenium] Navigated to home and clicked new-chat-button")
+        log_debug("[selenium] Navigated to home and clicked create-new-chat-button")
     except Exception as e:
         log_warning(f"[selenium] New chat button not clicked: {e}")
         # Fallback: navigate directly to home which should create a new chat

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -434,7 +434,17 @@ def process_prompt_in_chat(
         driver.get(chat_url)
         current_url = driver.current_url
         log_debug(f"[selenium][DEBUG] Current URL after navigation: {current_url}")
-        if chat_id not in current_url:
+
+        # Check if the chat is archived
+        try:
+            archived_message = driver.find_element(By.CLASS_NAME, "text-token-text-secondary").text
+            if "This conversation is archived" in archived_message:
+                log_warning(f"[selenium][WARN] Chat {chat_id} is archived and cannot be used.")
+                chat_id = None  # Mark chat as invalid
+        except Exception:
+            pass  # No archived message found, continue normally
+
+        if chat_id and chat_id not in current_url:
             log_warning(f"[selenium][WARN] URL mismatch: expected {chat_id}, got {current_url}")
             chat_id = None  # Mark chat as invalid
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `llm_engines/selenium_chatgpt.py` file, focusing on better error handling, enhanced logging, and the removal of deprecated or unreliable functionality. Key changes include improved debugging logs, enhanced URL validation and chat ID extraction, and the replacement of the chat renaming feature with a more reliable process for handling new chats.

### Enhanced Logging and Debugging:
* Added detailed debug logs to `_send_prompt_with_confirmation` to track each step of the prompt-sending process, including attempts, fallback mechanisms, and response stabilization.
* Improved logging in `_extract_chat_id` to handle invalid URLs and log errors when no chat ID can be extracted.

### Error Handling and Validation:
* Enhanced `_extract_chat_id` to validate input URLs and return `None` for invalid or non-string inputs.
* Introduced better error handling in `process_prompt_in_chat` to manage scenarios where elements are not interactable or responses timeout.

### Refactoring and Simplification:
* Replaced the deprecated `rename_and_send_prompt` method with a more robust `process_prompt_in_chat` function, which handles chat creation and prompt sending more reliably. The chat renaming logic has been commented out due to UI instability. [[1]](diffhunk://#diff-9d1339daf95d26faaa1e36b48dc5efed75c0e23e43d24d9bc0effe540caa7077L509-R513) [[2]](diffhunk://#diff-9d1339daf95d26faaa1e36b48dc5efed75c0e23e43d24d9bc0effe540caa7077L1008-R963)
* Removed the `wait_for_response_change` function and integrated response stabilization directly into `process_prompt_in_chat` for better maintainability.

### New Functionality:
* Added `go_to_chat_by_path` to navigate to specific chats using their paths, with error handling for timeouts and navigation issues.

### Miscellaneous:
* Updated comments in `_open_new_chat` to Italian for consistency with other localized comments. [[1]](diffhunk://#diff-9d1339daf95d26faaa1e36b48dc5efed75c0e23e43d24d9bc0effe540caa7077L330-R342) [[2]](diffhunk://#diff-9d1339daf95d26faaa1e36b48dc5efed75c0e23e43d24d9bc0effe540caa7077L341-R353) [[3]](diffhunk://#diff-9d1339daf95d26faaa1e36b48dc5efed75c0e23e43d24d9bc0effe540caa7077L350-R393)