### PR TITLE
Update event query logic for timezone checks

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -266,14 +266,15 @@ def get_due_events(now: datetime | None = None, tolerance_minutes: int = 5) -> l
     tz = ZoneInfo(os.getenv("TZ", "UTC"))
 
     with get_db() as db:
-        rows = db.execute(
-            """
-            SELECT * FROM scheduled_events 
-            WHERE delivered = 0 
-            AND datetime(date || ' ' || COALESCE(time, '00:00')) <= datetime('now', 'utc')
-            ORDER BY id
-            """
-        ).fetchall()
+        rows = (
+            db.execute(
+                """
+                SELECT * FROM scheduled_events
+                WHERE delivered = 0
+                ORDER BY id
+                """
+            ).fetchall()
+        )
 
     due: list[dict] = []
     for r in rows:


### PR DESCRIPTION
## Summary
- fetch all undelivered scheduled events without SQL time check
- filter events in Python using UTC timestamps and tolerance window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plugins.test_action_plugin')*

------
https://chatgpt.com/codex/tasks/task_e_687f92f65aec832892908a22a7007468