### PR TITLE
Refactor message handling into telegram interface

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -4,8 +4,11 @@ from typing import Any, Optional
 
 from core.logging_utils import log_debug, log_warning
 
-# Internal storage for interface objects
-_INTERFACES: dict[str, Any] = {}
+# Global registry for interface objects
+INTERFACE_REGISTRY: dict[str, Any] = {}
+
+# Backwards-compatibility alias
+_INTERFACES = INTERFACE_REGISTRY
 
 
 def register_interface(name: str, interface_obj: Any) -> None:

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -1,0 +1,22 @@
+"""Simple registry for active interface instances."""
+
+from typing import Any, Optional
+
+from core.logging_utils import log_debug, log_warning
+
+# Internal storage for interface objects
+_INTERFACES: dict[str, Any] = {}
+
+
+def register_interface(name: str, interface_obj: Any) -> None:
+    """Register an interface instance for later retrieval."""
+    _INTERFACES[name] = interface_obj
+    log_debug(f"[interfaces] Registered interface: {name}")
+
+
+def get_interface_by_name(name: str) -> Optional[Any]:
+    """Return a previously registered interface by name."""
+    iface = _INTERFACES.get(name)
+    if iface is None:
+        log_warning(f"[interfaces] Interface not found: {name}")
+    return iface

--- a/plugins/message_plugin.py
+++ b/plugins/message_plugin.py
@@ -8,14 +8,9 @@ from core.logging_utils import log_debug, log_info, log_warning, log_error
 class MessagePlugin:
     """Plugin to handle message-type actions across multiple interfaces."""
 
-    def __init__(self, interface_handlers: dict | None = None):
-        """Initialize the plugin with optional interface handlers."""
-        default_handlers = {
-            "telegram_bot": self._send_telegram_message,
-            "telegram": self._send_telegram_message,  # legacy alias
-        }
-        self.interface_handlers = interface_handlers or default_handlers
-        self.supported_interfaces = list(self.interface_handlers.keys())
+    def __init__(self):
+        """Initialize the plugin."""
+        self.supported_interfaces = ["telegram"]
         log_debug("[message_plugin] MessagePlugin initialized")
 
     @property
@@ -61,105 +56,21 @@ class MessagePlugin:
             # The actual execution is done via execute_action
 
     async def _handle_message_action(self, action: dict, context: dict, bot, original_message):
-        """Handle message action execution."""
+        """Handle message action execution using the interface registry."""
+        from core.interfaces import get_interface_by_name
+
         payload = action.get("payload", {})
-        text = payload.get("text", "")
-        target = payload.get("target")
-        thread_id = payload.get("thread_id")
-        interface = action.get("interface", self.supported_interfaces[0])
-        
-        log_debug(f"[message_plugin] Handling message action: {text[:50]}...")
-        log_debug(f"[message_plugin] Target: {target}, Thread: {thread_id}, Interface: {interface}")
+        interface_name = action.get("interface", self.supported_interfaces[0])
 
-        # Validate required fields
-        if not text:
-            log_warning("[message_plugin] Invalid message action: missing text")
+        log_debug(f"[message_plugin] Dispatching message via interface: {interface_name}")
+
+        interface = get_interface_by_name(interface_name)
+        if not interface:
+            log_warning(f"[message_plugin] Unsupported interface: {interface_name}")
             return
 
-        # If target is missing or invalid, use the original message's chat_id as fallback
-        if not target:
-            target = getattr(original_message, "chat_id", None)
-            log_debug(f"[message_plugin] No target specified, using original chat_id: {target}")
+        await interface.send_message(payload, original_message)
 
-        # If thread_id is missing but original message has one, use it as fallback
-        if not thread_id and hasattr(original_message, "chat_id"):
-            original_thread_id = getattr(original_message, "message_thread_id", None)
-            if original_thread_id:
-                thread_id = original_thread_id
-                log_debug(f"[message_plugin] No thread_id specified, using original thread_id: {thread_id}")
-
-        # Additional validation for target
-        if not target:
-            log_warning("[message_plugin] No valid target found, cannot send message")
-            return
-
-        # Route to appropriate interface
-        handler = self.interface_handlers.get(interface)
-        if handler:
-            await handler(bot, target, text, thread_id, original_message)
-        else:
-            log_warning(f"[message_plugin] Unsupported interface: {interface}")
-
-    async def _send_telegram_message(self, bot, target, text, thread_id, original_message):
-        """Send message via Telegram interface."""
-        try:
-            log_debug(f"[message_plugin] Sending message to {target} (thread_id: {thread_id}) with text: {text[:50]}...")
-
-            # Prepare kwargs for send_message
-            send_kwargs = {"chat_id": target, "text": text}
-            if thread_id:
-                send_kwargs["message_thread_id"] = thread_id
-
-            # Add reply_to_message_id if sending to the same chat as the original message
-            if (hasattr(original_message, "chat_id") and 
-                hasattr(original_message, "message_id") and 
-                target == original_message.chat_id):
-                send_kwargs["reply_to_message_id"] = original_message.message_id
-                log_debug(f"[message_plugin] Adding reply_to_message_id: {original_message.message_id}")
-
-            await bot.send_message(**send_kwargs)
-            log_info(f"[message_plugin] Message successfully sent to {target} (thread: {thread_id}, reply_to: {send_kwargs.get('reply_to_message_id', 'None')})")
-            
-        except Exception as e:
-            error_message = str(e)
-            
-            # Check if the error is specifically about thread not found
-            if thread_id and ("Message thread not found" in error_message or "thread not found" in error_message.lower()):
-                log_warning(f"[message_plugin] Thread {thread_id} not found in chat {target}, retrying without thread_id")
-                try:
-                    # Retry without thread_id but keep reply_to_message_id if applicable
-                    fallback_kwargs = {"chat_id": target, "text": text}
-                    if (hasattr(original_message, "chat_id") and 
-                        hasattr(original_message, "message_id") and 
-                        target == original_message.chat_id):
-                        fallback_kwargs["reply_to_message_id"] = original_message.message_id
-                    
-                    await bot.send_message(**fallback_kwargs)
-                    log_info(f"[message_plugin] Message successfully sent to {target} (fallback: no thread, reply_to: {fallback_kwargs.get('reply_to_message_id', 'None')})")
-                    return  # Success, exit the function
-                except Exception as no_thread_error:
-                    log_error(f"[message_plugin] Fallback without thread also failed for {target}: {no_thread_error}")
-                    # Continue to original fallback logic below
-            else:
-                log_error(f"[message_plugin] Failed to send message to {target} (thread: {thread_id}): {repr(e)}")
-            
-            # Try fallback to original chat if target was different
-            if hasattr(original_message, "chat_id") and target != original_message.chat_id:
-                try:
-                    fallback_thread_id = getattr(original_message, "message_thread_id", None)
-                    fallback_kwargs = {"chat_id": original_message.chat_id, "text": text}
-                    if fallback_thread_id:
-                        fallback_kwargs["message_thread_id"] = fallback_thread_id
-                    # Always add reply_to_message_id when falling back to original chat
-                    if hasattr(original_message, "message_id"):
-                        fallback_kwargs["reply_to_message_id"] = original_message.message_id
-
-                    log_debug(f"[message_plugin] Retrying with original chat_id: {original_message.chat_id} (thread: {fallback_thread_id}, reply_to: {fallback_kwargs.get('reply_to_message_id', 'None')})")
-                    await bot.send_message(**fallback_kwargs)
-                    log_info(f"[message_plugin] Message successfully sent to fallback chat: {original_message.chat_id} (thread: {fallback_thread_id}, reply_to: {fallback_kwargs.get('reply_to_message_id', 'None')})")
-                    
-                except Exception as fallback_error:
-                    log_error(f"[message_plugin] Fallback also failed: {fallback_error}")
 
 
 # Export the plugin class


### PR DESCRIPTION
## Summary
- add core `interfaces` registry for interface instances
- register the telegram interface and implement `send_message`
- simplify `MessagePlugin` to dispatch using the registry

## Testing
- `python -m py_compile core/interfaces.py interface/telegram_bot.py plugins/message_plugin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688781fda71c83289609b71c0c484c12