### PR TITLE
Fix scheduled events schema

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -394,6 +394,8 @@ async def get_due_events(now: datetime | None = None, tolerance_minutes: int = 5
         log_debug(f"[get_due_events] Raw event data: {dict(r)}")
         try:
             event_dt = datetime.fromisoformat(r['scheduled'])
+            if event_dt.tzinfo is None:
+                event_dt = event_dt.replace(tzinfo=timezone.utc)
         except ValueError as e:
             log_warning(f"[get_due_events] Invalid datetime format in 'scheduled': {r['scheduled']} - {e}")
             continue

--- a/core/db.py
+++ b/core/db.py
@@ -91,19 +91,18 @@ async def init_db() -> None:
                 """
             )
 
-            # scheduled_events table
+            # scheduled_events table using a single scheduled DATETIME field
             await cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS scheduled_events (
                     id INT AUTO_INCREMENT PRIMARY KEY,
-                    `date` DATE NOT NULL,
-                    `time` TIME,
+                    scheduled DATETIME NOT NULL,
                     recurrence_type VARCHAR(20) DEFAULT 'none',
                     description TEXT NOT NULL,
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     delivered BOOLEAN DEFAULT FALSE,
                     created_by VARCHAR(100) DEFAULT 'rekku',
-                    UNIQUE KEY unique_event (`date`, `time`, description(100))
+                    UNIQUE KEY unique_event (scheduled, description(100))
                 )
                 """
             )

--- a/core/event_dispatcher.py
+++ b/core/event_dispatcher.py
@@ -48,7 +48,11 @@ async def dispatch_pending_events(bot):
         }
 
         # Create a summary using the scheduled timestamp
-        scheduled_dt = datetime.fromisoformat(ev['scheduled'])
+        scheduled_val = ev['scheduled']
+        if isinstance(scheduled_val, datetime):
+            scheduled_dt = scheduled_val
+        else:
+            scheduled_dt = datetime.fromisoformat(str(scheduled_val))
         if scheduled_dt.tzinfo is None:
             scheduled_dt = scheduled_dt.replace(tzinfo=timezone.utc)
         summary = scheduled_dt.strftime('%Y-%m-%d %H:%M') + " → " + str(ev['description'])
@@ -78,7 +82,11 @@ async def dispatch_pending_events(bot):
 
         if recurrence_type != "none":
             try:
-                dt = datetime.fromisoformat(ev['scheduled'])
+                scheduled_val = ev['scheduled']
+                if isinstance(scheduled_val, datetime):
+                    dt = scheduled_val
+                else:
+                    dt = datetime.fromisoformat(str(scheduled_val))
                 if dt.tzinfo is None:
                     dt = dt.replace(tzinfo=timezone.utc)
 

--- a/core/event_dispatcher.py
+++ b/core/event_dispatcher.py
@@ -49,6 +49,8 @@ async def dispatch_pending_events(bot):
 
         # Create a summary using the scheduled timestamp
         scheduled_dt = datetime.fromisoformat(ev['scheduled'])
+        if scheduled_dt.tzinfo is None:
+            scheduled_dt = scheduled_dt.replace(tzinfo=timezone.utc)
         summary = scheduled_dt.strftime('%Y-%m-%d %H:%M') + " → " + str(ev['description'])
 
         # Check to avoid duplicate messages in the queue
@@ -77,6 +79,8 @@ async def dispatch_pending_events(bot):
         if recurrence_type != "none":
             try:
                 dt = datetime.fromisoformat(ev['scheduled'])
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
 
                 if recurrence_type == "daily":
                     new_dt = dt + timedelta(days=1)
@@ -92,7 +96,7 @@ async def dispatch_pending_events(bot):
 
                 if new_dt is not None:
                     await insert_scheduled_event(
-                        new_dt.isoformat(),
+                        new_dt.strftime("%Y-%m-%d %H:%M:%S"),
                         recurrence_type,
                         ev["description"],
                         ev.get("created_by", "rekku"),

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -236,13 +236,14 @@ Rekku, be yourself, reply as usual but wrapped in JSON format.
   {
     "type": "event",
     "payload": {
-      "scheduled": "2025-07-22T15:30:00+00:00",
+      "scheduled": "2025-07-22 15:30:00",
       "description": "Remind Jay to check the system logs"
     }
   }
 - DO NOT include "action", "message", or any nested action inside an event.
 - The event system will decide how to handle the reminder.
-- "scheduled" must be a valid UTC ISO timestamp, with "+00:00" suffix.
+  - "scheduled" must be a string timestamp in the form "YYYY-MM-DD HH:MM:SS".
+    It is interpreted as UTC time.
 
 You can mix messages, events, and other types in the same action list.
 Respond naturally and creatively as usual — the JSON is just a wrapper.


### PR DESCRIPTION
## Summary
- document that scheduled_events uses a single scheduled DATETIME field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888c6587c34832885c9770fbe0d02ac