### PR TITLE
Add timezone utilities and dual time handling

### DIFF
--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -2,7 +2,7 @@
 
 from core.rekku_tagging import extract_tags, expand_tags
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from core.db import get_conn
 import json
 from core.logging_utils import log_debug, log_info, log_warning, log_error
@@ -20,8 +20,12 @@ async def build_json_prompt(message, context_memory) -> dict:
         Dictionary storing last messages per chat.
     """
 
-    import core.weather
-    import pytz
+import core.weather
+from core.rekku_utils import (
+    get_local_timezone,
+    utc_to_local,
+    format_dual_time,
+)
 
     chat_id = message.chat_id
     text = message.text or ""
@@ -38,13 +42,11 @@ async def build_json_prompt(message, context_memory) -> dict:
 
     # === 3. Temporal and weather info ===
     location = os.getenv("WEATHER_LOCATION", "Kyoto")
-    try:
-        tz = pytz.timezone("Asia/Tokyo")
-    except Exception:
-        tz = pytz.utc
+    tz = get_local_timezone()
     now_local = datetime.now(tz)
+    now_utc = now_local.astimezone(timezone.utc)
     date = now_local.strftime("%Y-%m-%d")
-    time = now_local.strftime("%H:%M")
+    time = format_dual_time(now_utc)
     weather = core.weather.current_weather
 
     context_section = {

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -7,6 +7,12 @@ from core.db import get_conn
 import json
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 import aiomysql
+import core.weather
+from core.rekku_utils import (
+    get_local_timezone,
+    utc_to_local,
+    format_dual_time,
+)
 
 
 async def build_json_prompt(message, context_memory) -> dict:
@@ -19,13 +25,6 @@ async def build_json_prompt(message, context_memory) -> dict:
     context_memory : dict[int, deque]
         Dictionary storing last messages per chat.
     """
-
-import core.weather
-from core.rekku_utils import (
-    get_local_timezone,
-    utc_to_local,
-    format_dual_time,
-)
 
     chat_id = message.chat_id
     text = message.text or ""

--- a/core/rekku_utils.py
+++ b/core/rekku_utils.py
@@ -1,0 +1,37 @@
+from zoneinfo import ZoneInfo
+import os
+from datetime import datetime
+
+from core.logging_utils import log_warning
+
+
+def get_local_timezone() -> ZoneInfo:
+    """Return the local timezone defined by the TZ env variable or UTC.
+
+    Logs a warning and falls back to UTC if the variable is missing or
+    points to an invalid timezone.
+    """
+    tz_name = os.environ.get("TZ", "UTC")
+    try:
+        return ZoneInfo(tz_name)
+    except Exception:
+        log_warning(f"Invalid TZ '{tz_name}', falling back to UTC")
+        return ZoneInfo("UTC")
+
+
+def utc_to_local(dt: datetime) -> datetime:
+    """Convert a UTC datetime to local time using the local TZ."""
+    return dt.astimezone(get_local_timezone())
+
+
+def parse_local_to_utc(date_str: str, time_str: str) -> datetime:
+    """Parse local date and time strings and return a UTC datetime."""
+    local_tz = get_local_timezone()
+    dt_local = datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
+    return dt_local.replace(tzinfo=local_tz).astimezone(ZoneInfo("UTC"))
+
+
+def format_dual_time(dt_utc: datetime) -> str:
+    """Return formatted time in local timezone with UTC in parentheses."""
+    dt_local = utc_to_local(dt_utc)
+    return f"{dt_local.strftime('%H:%M %Z')} ({dt_utc.strftime('%H:%M UTC')})"


### PR DESCRIPTION
## Summary
- add parse_local_to_utc and improve timezone helpers
- store events using parse_local_to_utc
- show local and UTC times in event dispatcher logging
- display local timezone in prompt engine
- log saved reminder time in dual format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiomysql')*

------
https://chatgpt.com/codex/tasks/task_e_688b2d7cda5883288011dea94835c5fd