### PR TITLE
Generate unified action manifest at startup

### DIFF
--- a/core/ai_plugin_base.py
+++ b/core/ai_plugin_base.py
@@ -47,6 +47,6 @@ class AIPluginBase:
         """Return the list of action types this plugin supports."""
         return []
 
-    def get_prompt_instructions(self) -> dict[str, str]:
-        """Return per-action prompt instructions for all supported actions."""
+    def get_prompt_instructions(self, action_name: str) -> dict:
+        """Return prompt instructions for the given action."""
         return {}

--- a/plugins/bash_plugin.py
+++ b/plugins/bash_plugin.py
@@ -105,14 +105,17 @@ class BashPlugin(AIPluginBase):
         command = "\n".join(messages)
         return await self._run_command(command)
 
-    def get_supported_actions(self) -> set[str]:
+    def get_supported_actions(self) -> list[str]:
         """Return the action types supported by this plugin."""
-        return {"bash"}
+        return ["bash"]
 
-    def get_prompt_instructions(self) -> dict[str, str]:
-        example = '{"type": "bash", "payload": {"command": "ls -la"}}'
+    def get_prompt_instructions(self, action_name: str) -> dict:
+        """Return prompt instructions for the given action."""
+        if action_name != "bash":
+            return {}
         return {
-            "bash": "Execute a shell command on the host and return its output. Example: " + example
+            "description": "Run a bash command and return its output",
+            "payload": {"command": "echo hello"},
         }
 
     def get_rate_limit(self):

--- a/plugins/event_plugin.py
+++ b/plugins/event_plugin.py
@@ -127,25 +127,23 @@ class EventPlugin(AIPluginBase):
         """Return the action types this plugin supports."""
         return ["event"]
 
-    def get_supported_actions(self) -> set[str]:
+    def get_supported_actions(self) -> list[str]:
         """Return the action types supported by this plugin."""
-        return {"event"}
+        return ["event"]
 
-    def get_prompt_instructions(self) -> dict[str, str]:
+    def get_prompt_instructions(self, action_name: str) -> dict:
         """Prompt instructions for the supported actions."""
+        if action_name != "event":
+            return {}
         return {
-            "event": (
-                "You are receiving an `event` previously scheduled by Rekku.\n"
-                "This is not a new event creation. Do not create a new event as part of your"
-                " response unless you intentionally reschedule or chain it.\n"
-                "Your goal is to react to the event:\n"
-                "- Notify the user via a message if needed\n"
-                "- Execute the action if it's an internal trigger\n"
-                "- Communicate if the event is too late to be meaningful\n"
-                "- You may return no actions if it's already handled\n"
-                "❌ Do NOT create a duplicate event. ✅ Respond with a message, command, or"
-                " memory if appropriate."
-            )
+            "description": "Schedule a future reminder or event",
+            "payload": {
+                "date": "2025-07-30",
+                "time": "13:00",
+                "repeat": "weekly",
+                "description": "Remind me to water the plants",
+                "created_by": "rekku",
+            },
         }
 
     def execute_action(self, action: dict, context: dict, bot, original_message):

--- a/plugins/message_plugin.py
+++ b/plugins/message_plugin.py
@@ -28,21 +28,21 @@ class MessagePlugin:
         """Return the action types this plugin supports."""
         return ["message"]
 
-    def get_supported_actions(self) -> set[str]:
+    def get_supported_actions(self) -> list[str]:
         """Return the action types this plugin supports."""
-        return {"message"}
+        return ["message"]
 
-    def get_prompt_instructions(self) -> dict[str, str]:
+    def get_prompt_instructions(self, action_name: str) -> dict:
         """Prompt instructions for supported actions."""
-        example = (
-            '{"type": "message", "interface": "telegram", "payload": {"text": "Hello!", '
-            '"target": "123456789"}}'
-        )
+        if action_name != "message":
+            return {}
         return {
-            "message": (
-                "Send a text message via a supported interface. Provide the target chat_id and text. "
-                "Example: " + example
-            )
+            "description": "Send a text message via a supported interface",
+            "payload": {
+                "text": "Hello!",
+                "target": "123456789",
+                "interface": "telegram",
+            },
         }
 
     async def execute_action(self, action: dict, context: dict, bot, original_message):

--- a/plugins/reddit_plugin.py
+++ b/plugins/reddit_plugin.py
@@ -24,11 +24,21 @@ class RedditPlugin:
     def get_supported_action_types(self) -> list[str]:
         return ["message"]
 
-    def get_supported_actions(self) -> dict:
+    def get_supported_actions(self) -> list[str]:
+        return ["message"]
+
+    def get_prompt_instructions(self, action_name: str) -> dict:
+        if action_name != "message":
+            return {}
         return {
-            "message": (
-                'Post a message to Reddit: {"actions":[{"type":"message","interface":"reddit","payload":{"text":"...","target":"r/my_subreddit","title":"...","flair_id":"..."}}]}'
-            )
+            "description": "Post a submission or comment to Reddit",
+            "payload": {
+                "text": "Post text",
+                "target": "r/my_subreddit",
+                "title": "Optional title",
+                "flair_id": "flair id",
+                "thread_id": "comment or post id",
+            },
         }
 
     def execute_action(self, action: dict, context: dict, bot, original_message):

--- a/plugins/terminal/terminal.py
+++ b/plugins/terminal/terminal.py
@@ -82,13 +82,15 @@ class TerminalPlugin(AIPluginBase):
         command = "\n".join(messages)
         return await self._send_command(command)
 
-    def get_supported_actions(self) -> set[str]:
-        return {"terminal"}
+    def get_supported_actions(self) -> list[str]:
+        return ["terminal"]
 
-    def get_prompt_instructions(self) -> dict[str, str]:
-        example = '{"type": "terminal", "payload": {"command": "echo hello"}}'
+    def get_prompt_instructions(self, action_name: str) -> dict:
+        if action_name != "terminal":
+            return {}
         return {
-            "terminal": "Open a persistent shell session and run commands interactively. Example: " + example
+            "description": "Run commands in a persistent shell session",
+            "payload": {"command": "echo hello"},
         }
 
     def get_target(self, trainer_message_id):


### PR DESCRIPTION
## Summary
- build a unified `actions` block during initialization
- attach the `actions` list to every prompt
- ignore any top level `description` in `validate_action`
- update plugins to provide structured prompt instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b82bdaa588328a6efa57fd68625bd