### PR TITLE
Fix undefined variable error when creating bio table

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -156,20 +156,25 @@ async def ensure_core_tables() -> None:
             await init_db()
             _db_initialized = True
 
-        db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS bio (
-                id TEXT PRIMARY KEY,
-                known_as TEXT,
-                likes TEXT,
-                not_likes TEXT,
-                information TEXT,
-                past_events TEXT,
-                feelings TEXT,
-                contacts TEXT
-            )
-            """
-        )
+        conn = await get_conn()
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS bio (
+                        id TEXT PRIMARY KEY,
+                        known_as TEXT,
+                        likes TEXT,
+                        not_likes TEXT,
+                        information TEXT,
+                        past_events TEXT,
+                        feelings TEXT,
+                        contacts TEXT
+                    )
+                    """
+                )
+        finally:
+            conn.close()
 
 # 🧠 Insert a new memory into the database
 async def insert_memory(


### PR DESCRIPTION
## Summary
- fix `db` NameError in `ensure_core_tables`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c0a5815dc83289330d22685191452