### PR TITLE
Fix missing from_user when delegating message actions

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -339,6 +339,10 @@ async def _handle_plugin_action(
             msg_data = vars(original_message).copy() if original_message else {}
             msg_data["text"] = action.get("payload", {}).get("text", "")
             from types import SimpleNamespace
+            if "from_user" not in msg_data:
+                msg_data["from_user"] = SimpleNamespace(
+                    id=0, full_name="system", username="system"
+                )
             message_obj = SimpleNamespace(**msg_data)
             try:
                 result = handler(bot, message_obj, context)


### PR DESCRIPTION
## Summary
- ensure a `from_user` attribute exists when delegating message actions via `plugin_instance`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c0f7df8b083288a594412ce6c737e