### PR TITLE
Refactor event prompts dispatch

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -343,6 +343,9 @@ async def _handle_plugin_action(
                 msg_data["from_user"] = SimpleNamespace(
                     id=0, full_name="system", username="system"
                 )
+            if "message_id" not in msg_data:
+                from datetime import datetime
+                msg_data["message_id"] = int(datetime.utcnow().timestamp() * 1000) % 1_000_000
             message_obj = SimpleNamespace(**msg_data)
             try:
                 result = handler(bot, message_obj, context)

--- a/core/db.py
+++ b/core/db.py
@@ -162,7 +162,7 @@ async def ensure_core_tables() -> None:
                 await cur.execute(
                     """
                     CREATE TABLE IF NOT EXISTS bio (
-                        id TEXT PRIMARY KEY,
+                        id VARCHAR(255) PRIMARY KEY,
                         known_as TEXT,
                         likes TEXT,
                         not_likes TEXT,

--- a/core/event_dispatcher.py
+++ b/core/event_dispatcher.py
@@ -67,9 +67,7 @@ async def dispatch_pending_events(bot):
 
         prompt = event_plugin._create_event_prompt(ev)
         old_instructions = prompt.get("instructions", "")
-        prompt["instructions"] = (
-            "🕒 You are the Event Dispatcher\n\n" + old_instructions
-        )
+        prompt["instructions"] = "🕒 Event Dispatcher\n\n" + old_instructions
 
         summary = format_dual_time(scheduled_dt) + " → " + str(ev["description"])
 

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -164,36 +164,10 @@ async def _consumer_loop() -> None:
             try:
                 # Check if this is an event prompt
                 if "event_prompt" in final:
-                    # For events, we need to use the LLM plugin directly with the structured prompt
-                    plugin = plugin_instance.get_plugin()
-                    if plugin and hasattr(plugin, 'handle_incoming_message'):
-                        # Create a mock message for event processing
-                        from types import SimpleNamespace
-                        event_id = final['event_prompt'].get('input', {}).get('source', {}).get('event_id')
-                        event_message = SimpleNamespace(
-                            message_id=f"event_{event_id}",
-                            chat_id="SYSTEM_SCHEDULER",
-                            text="Scheduled event: " + str(final['event_prompt']['input']['payload']['description']),
-                            from_user=SimpleNamespace(
-                                id=-1,
-                                full_name="Rekku Scheduler",
-                                username="rekku_scheduler"
-                            ),
-                            date=datetime.utcnow(),
-                            reply_to_message=None,
-                            chat=SimpleNamespace(
-                                id="SYSTEM_SCHEDULER",
-                                type="private",
-                                title="System Scheduler"
-                            ),
-                            message_thread_id=None,
-                            event_id=event_id
-                        )
-                        await plugin.handle_incoming_message(
-                            final["bot"], event_message, final["event_prompt"]
-                        )
-                    else:
-                        log_error("[QUEUE] No LLM plugin available or doesn't support handle_incoming_message")
+                    # Deliver the structured event prompt using the standard pipeline
+                    await plugin_instance.handle_incoming_message(
+                        final["bot"], None, final["event_prompt"]
+                    )
                 else:
                     await plugin_instance.handle_incoming_message(
                         final["bot"], final["message"], final["context"]


### PR DESCRIPTION
## Summary
- dispatch pending events using standardized prompts
- ensure event queue hands prompts to the main plugin pipeline

## Testing
- `python -m py_compile core/event_dispatcher.py core/message_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_688c1c03b2848328bd3670f2508a42a7