### PR TITLE
Add Docker Hub cleanup job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,3 +73,35 @@ jobs:
         docker tag ${{ secrets.DOCKERHUB_USERNAME }}/rekku_freedom_project:${{ steps.gitversion_build.outputs.semVer }} ${{ secrets.DOCKERHUB_USERNAME }}/rekku_freedom_project:${{ steps.gitversion_build.outputs.semVer }}-$sanitized_branch_name
         docker push ${{ secrets.DOCKERHUB_USERNAME }}/rekku_freedom_project:${{ steps.gitversion_build.outputs.semVer }}-$sanitized_branch_name
 
+  cleanup-images:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Remove dangling and old PR images from Docker Hub
+        env:
+          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          repo="$USERNAME/rekku_freedom_project"
+          token=$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          # Delete untagged images
+          curl -s -H "Authorization: JWT $token" "https://hub.docker.com/v2/repositories/$repo/images?page_size=100" | \
+            jq -r '.results[] | select((.digest != null) and (.tags | length == 0)) | .digest' | while read digest; do
+              echo "Deleting dangling image $digest"
+              curl -s -H "Authorization: JWT $token" -X DELETE "https://hub.docker.com/v2/repositories/$repo/images/$digest/"
+            done
+
+          # Delete PR tags older than two weeks
+          cutoff=$(date -u -d '14 days ago' +%s)
+          curl -s -H "Authorization: JWT $token" "https://hub.docker.com/v2/repositories/$repo/tags?page_size=100" | \
+            jq -r '.results[] | .name + " " + .last_updated' | while read name updated; do
+              if [[ "$name" == *-pr-* ]]; then
+                ts=$(date -u -d "$updated" +%s)
+                if [ $ts -lt $cutoff ]; then
+                  echo "Deleting tag $name (older than two weeks)"
+                  curl -s -H "Authorization: JWT $token" -X DELETE "https://hub.docker.com/v2/repositories/$repo/tags/$name/"
+                fi
+              fi
+            done
+


### PR DESCRIPTION
## Summary
- extend build-release workflow with a cleanup job
- remove dangling images and PR tags older than two weeks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c397460d083289d2244440edec9b0