### PR TITLE
Unify action metadata across plugins

### DIFF
--- a/core/core_initializer.py
+++ b/core/core_initializer.py
@@ -2,6 +2,7 @@
 
 import os
 import importlib
+import inspect
 from pathlib import Path
 from core.logging_utils import log_info, log_error, log_warning, log_debug
 from core.config import get_active_llm
@@ -15,7 +16,7 @@ class CoreInitializer:
         self.active_interfaces = []
         self.active_llm = None
         self.startup_errors = []
-        self.actions_block = {"actions": []}
+        self.actions_block = {"available_actions": {}, "action_instructions": {}}
     
     async def initialize_all(self, notify_fn=None):
         """Initialize all Rekku components in the correct order."""
@@ -167,29 +168,85 @@ class CoreInitializer:
             log_info("[core_initializer] All pending async plugins processed")
 
     def _build_actions_block(self):
-        """Collect supported actions from plugins for prompt injection."""
+        """Collect and validate action schemas from all plugins and interfaces."""
         from core.action_parser import _load_action_plugins
 
-        actions = []
+        available_actions = {}
+        action_instructions = {}
+
+        def _register(action_type: str, iface: str, schema: dict, instr_fn):
+            required = schema.get("required_fields", [])
+            optional = schema.get("optional_fields", [])
+            if not isinstance(required, list) or not isinstance(optional, list):
+                raise ValueError(f"Invalid schema for {action_type} in {iface}")
+
+            if action_type not in available_actions:
+                available_actions[action_type] = {
+                    "description": schema.get("description", ""),
+                    "interfaces": {},
+                }
+
+            if iface in available_actions[action_type]["interfaces"]:
+                raise ValueError(f"Duplicate declaration for {action_type} in {iface}")
+
+            available_actions[action_type]["interfaces"][iface] = {
+                "required_fields": required,
+                "optional_fields": optional,
+            }
+
+            instr = instr_fn(action_type) if instr_fn else None
+            if not instr:
+                raise ValueError(f"Missing prompt instructions for {action_type} in {iface}")
+            action_instructions[action_type] = instr
+
+        # --- Load action plugins ---
         try:
             for plugin in _load_action_plugins():
-                if hasattr(plugin, "get_supported_actions") and hasattr(plugin, "get_prompt_instructions"):
-                    supported = plugin.get_supported_actions()
-                    for act in supported:
-                        try:
-                            info = plugin.get_prompt_instructions(act)
-                            if info:
-                                actions.append({
-                                    "type": act,
-                                    "description": info.get("description", ""),
-                                    "payload": info.get("payload", {}),
-                                })
-                        except Exception as e:
-                            log_warning(f"[core_initializer] Missing prompt info for {act} in {plugin}: {e}")
+                if not hasattr(plugin, "get_supported_actions"):
+                    continue
+                iface = (
+                    plugin.get_interface_id()
+                    if hasattr(plugin, "get_interface_id")
+                    else plugin.__class__.__name__.lower()
+                )
+                supported = plugin.get_supported_actions()
+                if not isinstance(supported, dict):
+                    raise ValueError(f"Plugin {iface} must return dict from get_supported_actions")
+                for act, schema in supported.items():
+                    _register(act, iface, schema, getattr(plugin, "get_prompt_instructions", None))
         except Exception as e:
-            log_error(f"[core_initializer] Failed to build actions block: {repr(e)}")
+            log_error(f"[core_initializer] Failed loading plugin actions: {e}")
+            self.startup_errors.append(str(e))
 
-        self.actions_block = {"actions": actions}
+        # --- Load interface classes ---
+        interface_dir = Path(__file__).parent.parent / "interface"
+        for file in interface_dir.glob("*.py"):
+            if file.name.startswith("_") or file.name.endswith(".disabled"):
+                continue
+            mod_name = f"interface.{file.stem}"
+            try:
+                module = importlib.import_module(mod_name)
+            except Exception as e:
+                log_warning(f"[core_initializer] Could not import {mod_name}: {e}")
+                continue
+            for _name, obj in inspect.getmembers(module, inspect.isclass):
+                if not hasattr(obj, "get_supported_actions"):
+                    continue
+                iface = obj.get_interface_id() if hasattr(obj, "get_interface_id") else obj.__name__.lower()
+                try:
+                    supported = obj.get_supported_actions()
+                    if not isinstance(supported, dict):
+                        raise ValueError(f"Interface {iface} must return dict from get_supported_actions")
+                    instr_fn = getattr(obj, "get_prompt_instructions", None)
+                    for act, schema in supported.items():
+                        _register(act, iface, schema, instr_fn)
+                except Exception as e:
+                    log_error(f"[core_initializer] Error processing interface {iface}: {e}")
+
+        self.actions_block = {
+            "available_actions": available_actions,
+            "action_instructions": action_instructions,
+        }
     
     def _display_startup_summary(self):
         """Display a comprehensive startup summary."""

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -108,10 +108,15 @@ async def build_json_prompt(message, context_memory) -> dict:
         "interface_instructions": interface_instructions,
     }
 
-    # Include unified actions block from the initializer
+    # Include unified actions metadata from the initializer
     try:
         from core.core_initializer import core_initializer
-        prompt_with_instructions["actions"] = core_initializer.actions_block.get("actions", [])
+        prompt_with_instructions["available_actions"] = core_initializer.actions_block.get(
+            "available_actions", {}
+        )
+        prompt_with_instructions["action_instructions"] = core_initializer.actions_block.get(
+            "action_instructions", {}
+        )
     except Exception as e:
         log_warning(f"[prompt_engine] Failed to inject actions block: {e}")
 

--- a/plugins/event_plugin.py
+++ b/plugins/event_plugin.py
@@ -127,9 +127,20 @@ class EventPlugin(AIPluginBase):
         """Return the action types this plugin supports."""
         return ["event"]
 
-    def get_supported_actions(self) -> list[str]:
-        """Return the action types supported by this plugin."""
-        return ["event"]
+    @staticmethod
+    def get_interface_id() -> str:
+        """Return the unique identifier for this internal interface."""
+        return "event"
+
+    def get_supported_actions(self) -> dict:
+        """Return schema information for supported actions."""
+        return {
+            "event": {
+                "required_fields": ["date", "description"],
+                "optional_fields": ["time", "repeat", "created_by"],
+                "description": "Create or schedule a future event",
+            }
+        }
 
     def get_prompt_instructions(self, action_name: str) -> dict:
         """Prompt instructions for the supported actions."""


### PR DESCRIPTION
## Summary
- treat event plugin like a proper interface
- provide unified action metadata and instructions to `prompt_engine`
- validate all plugin and interface actions during initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c3fc3de9483289bff447dd9e649ae