### PR TITLE
Add quickstart, contributing guide and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/github/license/XargonWan/Rekku_Freedom_Project)](https://img.shields.io/github/license/XargonWan/Rekku_Freedom_Project)
 ![Docker Pulls](https://img.shields.io/docker/pulls/xargonwan/rekku_freedom_project)
+[![Docs Status](https://readthedocs.org/projects/rekku-freedom-project/badge/?version=latest)](https://rekku-freedom-project.readthedocs.io/en/latest/?badge=latest)
 
 | Branch   | Build Status                                                                                                                                         |
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -25,6 +26,19 @@ Currently, the project is tailored for a single persona named Rekku. However, in
 > — **Rekku**
 
 ---
+
+## 🚀 Quickstart
+
+1. Copy `.env.example` to `.env` and fill in `BOTFATHER_TOKEN` and `TRAINER_ID`.
+2. Start the stack:
+   ```bash
+   docker compose up
+   ```
+3. If you use the Selenium engine, open `http://<host>:5006` and log in to ChatGPT.
+
+Database backups are stored in `./backups/`. Stop the services with `Ctrl+C` or `docker compose down`.
+
+See the [full quickstart guide](https://rekku-freedom-project.readthedocs.io/en/latest/quickstart.html) for more details.
 
 ## 📦 Features Overview
 
@@ -281,9 +295,35 @@ Feel free to test it and enhance it if you got an API ke, all contributions are 
 
 ## 📚 Documentation
 
-Full documentation for the Rekku Freedom Project is hosted on
-[Read the Docs](https://rekku-freedom-project.readthedocs.io). You can also
-build the docs locally from the `docs/` directory using Sphinx.
+Full documentation for the Rekku Freedom Project is available on our
+[Read the Docs wiki](https://rekku-freedom-project.readthedocs.io).
+The site is rebuilt automatically on every push via Read the Docs CI/CD and the
+current status is shown by the badge at the top of this page.
+
+You can also build the documentation locally:
+
+```bash
+pip install -r requirements.txt
+sphinx-build -b html docs docs/_build/html
+```
+
+Open `docs/_build/html/index.html` in your browser to view the pages.
+
+---
+
+## 🤝 Contributing
+
+Pull requests are welcome! Follow the commit semantics below and ensure your code
+passes `python -m py_compile`. For major changes, open an issue to discuss them
+beforehand. Improvements to the documentation are encouraged as well.
+
+## ❓ FAQ
+
+### Can I use this to create my own persona?
+
+Yes. Once the project is mature and stable, you will be able to customize it to
+run your own persona. Some tweaks are still required to support external
+characters, but enabling custom personas is the final goal.
 
 ---
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,5 +16,5 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = []
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,6 @@
+Contributing
+============
+
+We welcome pull requests for bug fixes and new features. Please follow the commit semantics outlined in the README and ensure your code passes ``python -m py_compile``. For larger changes, open an issue first to discuss your ideas.
+
+Documentation contributions are also appreciated. Update the ``docs/`` sources and verify that ``sphinx-build`` completes without errors.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,7 @@
+FAQ
+===
+
+Can I create my own persona?
+---------------------------
+
+Yes. The project aims to support custom personas once the core is stable. Some tweaks are still required to fully externalize persona data, but enabling user-defined characters is the final goal.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,12 @@
 Rekku Freedom Project Documentation
 ===================================
 
-Welcome to the **Rekku Freedom Project** documentation. These pages provide an overview of the
-project and instructions for getting started.
+Welcome to the **Rekku Freedom Project** documentation. These pages are built
+with Sphinx and hosted on **Read the Docs**. Every push to the repository
+triggers a new build of this wiki.
+
+The following sections provide an overview of the project and instructions for
+getting started.
 
 .. toctree::
    :maxdepth: 2
@@ -14,3 +18,16 @@ project and instructions for getting started.
    features
    architecture
    plugins
+   contributing
+   faq
+
+Building the Documentation
+--------------------------
+
+Install the documentation requirements from the repository root and run:
+
+.. code-block:: bash
+
+   sphinx-build -b html docs docs/_build/html
+
+The generated HTML files will be available under ``docs/_build/html``.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -11,6 +11,13 @@ Terminal
 sent to the bot are executed in a background ``/bin/bash`` process and the
 output is returned.
 
+Bash
+----
+
+``bash_plugin`` executes one-off shell commands and returns the output.
+Every command is also reported to the configured ``TRAINER_ID`` so that
+the trainer can audit activity.
+
 Event
 -----
 
@@ -22,3 +29,16 @@ Message
 
 ``message_plugin`` handles text message actions across multiple interfaces. It is
 used internally by other plugins to send replies.
+
+Reddit Interface
+----------------
+
+``reddit_interface`` allows Rekku to read posts, handle direct messages and
+manage subreddit subscriptions. Credentials for Reddit must be provided in the
+``.env`` file.
+
+Reddit Actions
+--------------
+
+The ``reddit`` plugin exposes actions for creating posts and comments via
+``asyncpraw``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ asyncpraw
 praw
 requests
 snscrape
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
## Summary
- add quickstart steps to the README
- link contributing guidelines and explain custom persona support
- add Contributing and FAQ pages to docs
- include new pages in the docs index

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c6145f82083288e9186654a22c94e