### PR TITLE
docs: add project structure overview and plugin setup guides

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,10 +20,12 @@ getting started.
    installation
    usage
    quickstart
+   project_structure
    features
    architecture
    llm_engines
    plugins
+   plugin_setup
    contributing
    faq
 

--- a/docs/plugin_setup.rst
+++ b/docs/plugin_setup.rst
@@ -1,0 +1,64 @@
+Configuring Plugins (ELI5)
+==========================
+
+.. graphviz::
+
+   digraph setup {
+       rankdir=LR;
+       A [label="1. Get API keys/tokens"];
+       B [label="2. Fill them in .env"];
+       C [label="3. Install dependencies"];
+       D [label="4. Run Rekku"];
+       A -> B -> C -> D;
+   }
+
+This page explains how to enable built-in plugins using plain-language steps.
+
+Reddit
+------
+
+1. Create a new app on `https://www.reddit.com/prefs/apps <https://www.reddit.com/prefs/apps>`_.
+2. Copy the credentials into your ``.env`` file::
+
+      REDDIT_CLIENT_ID=...
+      REDDIT_CLIENT_SECRET=...
+      REDDIT_USERNAME=...
+      REDDIT_PASSWORD=...
+      REDDIT_USER_AGENT=rekku-agent
+3. Start the bot. Reddit actions will now work.
+
+Telegram Bot
+------------
+
+1. In Telegram, talk to **@BotFather** and create a bot.
+2. Paste the given token into ``BOTFATHER_TOKEN`` (or ``TELEGRAM_TOKEN``) in ``.env``.
+3. Set ``TRAINER_ID`` to your own Telegram user ID so you can control the bot.
+4. Launch Rekku with ``python main.py`` and message your bot.
+
+Telethon Userbot
+----------------
+
+1. Visit `https://my.telegram.org <https://my.telegram.org>`_ and log in.
+2. Create an API ID and API hash.
+3. Add them to ``.env``::
+
+      API_ID=12345
+      API_HASH=abcdef123456
+      SESSION=rekku_userbot
+4. On first run you will be asked for your phone number and a confirmation code to create the session file.
+
+X Interface
+-----------
+
+1. Set your X handle in ``.env``::
+
+      X_USERNAME=yourname
+2. Timeline and search features rely on ``snscrape`` which may not work on Python 3.12.
+
+Discord Interface
+-----------------
+
+1. Create a bot at `https://discord.com/developers/applications <https://discord.com/developers/applications>`_.
+2. Add a ``DISCORD_TOKEN`` entry to your ``.env`` with the bot token.
+3. The current interface is a stub; expand ``interface/discord_interface.py`` to connect the token and send messages.
+

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -10,6 +10,8 @@ Plugins
 The project includes several optional plugins that implement additional actions
 or storage.
 
+For step-by-step setup instructions see :doc:`plugin_setup`.
+
 Terminal
 --------
 

--- a/docs/project_structure.rst
+++ b/docs/project_structure.rst
@@ -1,0 +1,30 @@
+Project Structure
+=================
+
+The Rekku Freedom Project is organized into modular packages. Understanding the layout helps newcomers navigate the codebase.
+
+Repository Layout
+-----------------
+
+- ``core`` – foundational services such as configuration, logging, message queue, and database access.
+- ``interface`` – chat connectors for platforms like Telegram, Discord, and Reddit.
+- ``llm_engines`` – integrations with language model backends.
+- ``plugins`` – extend Rekku with action plugins (e.g., terminal, event).
+- ``automation_tools`` – helper scripts for development and deployment.
+- ``tests`` – automated test suite.
+
+Component Relationships
+-----------------------
+
+The diagram below shows how the main components interact.
+
+.. graphviz::
+
+   digraph Rekku {
+       rankdir=LR;
+       node [shape=box];
+       Users -> Interfaces -> Core -> "LLM Engines";
+       Core -> Plugins -> "External Services";
+       Core -> Database;
+   }
+


### PR DESCRIPTION
## Summary
- document repository layout in a new `project_structure` page
- include a graphviz diagram outlining how core modules interact
- link the new page from the main documentation index
- add an ELI5 plugin setup guide for Reddit, Telegram, Telethon, X, and Discord and cross-link it from the docs

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot; No module named 'dotenv')*
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found: sphinx-build)*


------
https://chatgpt.com/codex/tasks/task_e_688df41e63ec832887851844db77962e