### PR TITLE
fix: standardize interface registration with core initializer

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ getting started.
    auto_response
    llm_engines
    plugins
+   interfaces
    contributing
    faq
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,0 +1,51 @@
+Interfaces
+==========
+
+This guide explains how to add a new chat interface and expose its actions to the
+core system.
+
+1. **Create the module**
+   Place a new ``*.py`` file under the ``interface/`` directory.  Removing the
+   file later cleanly removes the interface from Rekku.
+
+2. **Declare actions**
+   Implement ``get_supported_actions`` on the interface class.  The method should
+   return a mapping of action names to a schema describing the required and
+   optional fields.
+
+3. **Optional prompt instructions**
+   If the LLM needs extra guidance for an action, implement
+   ``get_prompt_instructions(action_type)`` and return a dictionary of prompt
+   snippets.
+
+4. **Register the interface**
+   When the interface starts, call ``register_interface`` to make the instance
+   discoverable and notify the core initializer that it is active.
+
+.. code-block:: python
+
+   from core.core_initializer import register_interface, core_initializer
+
+   class MyInterface:
+       @staticmethod
+       def get_interface_id():
+           return "myiface"
+
+       @staticmethod
+       def get_supported_actions():
+           return {
+               "message_myiface": {
+                   "required_fields": ["text"],
+                   "optional_fields": [],
+                   "description": "Send a message over MyInterface.",
+               }
+           }
+
+       async def start(self):
+           register_interface("myiface", self)
+           core_initializer.register_interface("myiface")
+
+   INTERFACE_CLASS = MyInterface
+
+With these pieces in place the core initializer will automatically collect the
+interface's actions and make them available to the LLM.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -61,14 +61,31 @@ Action Plugin
 
 Action plugins process the actions returned by an LLM.  Create a new file under
 ``plugins/`` and subclass ``PluginBase`` or ``AIPluginBase`` if the plugin needs
-to interact with language model prompts.  At minimum expose a ``PLUGIN_CLASS``
-variable so the loader can locate your class.
+to interact with language model prompts.  Each plugin is self-contained; removing
+the file removes the action from the system.  To participate in the action
+registry the plugin must expose a ``PLUGIN_CLASS`` variable and implement
+``get_supported_actions``.  Optional prompt guidance can be provided via
+``get_prompt_instructions``.
 
 .. code-block:: python
 
    from core.ai_plugin_base import AIPluginBase
 
    class MyActionPlugin(AIPluginBase):
+       def get_supported_actions(self):
+           return {
+               "my_action": {
+                   "required_fields": ["value"],
+                   "optional_fields": [],
+                   "description": "Do something with 'value'",
+               }
+           }
+
+       def get_prompt_instructions(self, action_type):
+           if action_type == "my_action":
+               return {"system": "Describe how to call my_action"}
+           return {}
+
        def handle_incoming_message(self, bot, message, prompt):
            ...  # perform work
 
@@ -114,18 +131,34 @@ or JSON actions.  After placing the module, select it at runtime using the
 Interface
 ~~~~~~~~~
 
-Interfaces provide ingress/egress channels for messages.  A minimal interface
-exposes ``start()`` to begin listening and registers itself using
-``register_interface`` from ``core.interfaces``.
+Interfaces provide ingress/egress channels for messages and can also expose
+their own actions.  A minimal interface defines action schemas, calls
+``register_interface`` to make itself discoverable and then notifies the core
+initializer that it is active.
 
 .. code-block:: python
 
-   from core.interfaces import register_interface
+   from core.core_initializer import register_interface, core_initializer
 
    class MyInterface:
-       async def start(self):
-           ...
-           register_interface("myiface", self)
+       @staticmethod
+       def get_interface_id():
+           return "myiface"
 
-Interfaces typically forward incoming messages to ``plugin_instance.handle_incoming_message``
-so that the active LLM engine can process them.
+       @staticmethod
+       def get_supported_actions():
+           return {
+               "message_myiface": {
+                   "required_fields": ["text"],
+                   "optional_fields": [],
+                   "description": "Send a message over MyInterface.",
+               }
+           }
+
+       async def start(self):
+           register_interface("myiface", self)
+           core_initializer.register_interface("myiface")
+
+Interfaces typically forward incoming messages to
+``plugin_instance.handle_incoming_message`` so that the active LLM engine can
+process them.

--- a/interface/cli.py
+++ b/interface/cli.py
@@ -6,6 +6,7 @@ import queue
 from core.logging_utils import log_debug, log_info
 from core.plugin_base import PluginBase
 from core.message_queue import MessageQueue
+from core.core_initializer import register_interface, core_initializer
 
 # Register event_type for CLI
 EVENT_TYPE_CLI = "message_cli"
@@ -86,4 +87,12 @@ class CLIInterface(PluginBase):
         msg = {"type": EVENT_TYPE_CLI_EXEC, "command": command}
         self.queue.put(msg)
 
-PLUGIN_CLASS = CLIInterface
+INTERFACE_CLASS = CLIInterface
+
+
+def start_cli_interface():
+    """Instantiate and register the CLI interface with the core."""
+    cli = CLIInterface()
+    register_interface("cli", cli)
+    core_initializer.register_interface("cli")
+    return cli

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -1032,7 +1032,3 @@ class TelegramInterface:
 # Register TelegramInterface for discovery by the core
 PLUGIN_CLASS = TelegramInterface
 
-# Ensure the action type is registered globally
-from core.action_parser import set_available_plugins
-set_available_plugins([TelegramInterface])
-

--- a/interface/telethon_userbot.py
+++ b/interface/telethon_userbot.py
@@ -17,6 +17,7 @@ from core.config import TRAINER_ID
 from core import blocklist, response_proxy, say_proxy, recent_chats
 from core.context import context_command
 from core.auto_response import request_llm_delivery
+from core.core_initializer import register_interface, core_initializer
 import traceback
 
 load_dotenv()
@@ -33,6 +34,7 @@ last_selected_chat = {}
 message_id = None
 
 client = TelegramClient(SESSION, API_ID, API_HASH)
+register_interface("telegram_userbot", client)
 
 def escape_markdown(text):
     return re.sub(r'([_*\[\]()~`>#+=|{}.!-])', r'\\\1', text)
@@ -254,7 +256,6 @@ async def main():
         asyncio.create_task(send())
     
     # Initialize core system with notify function
-    from core.core_initializer import core_initializer
     await core_initializer.initialize_all(notify_fn=telegram_notify)
     
     log_info("🧞‍♀️ Rekku Userbot (Telethon) is online.")

--- a/interface/x_interface.py
+++ b/interface/x_interface.py
@@ -16,7 +16,7 @@ SNSCRAPE_AVAILABLE = False
 sntwitter = None
 
 from core.logging_utils import log_info, log_debug, log_warning
-from core.core_initializer import register_interface
+from core.core_initializer import register_interface, core_initializer
 from core.auto_response import request_llm_delivery
 
 log_warning("[x_interface] snscrape disabled due to Python 3.12 compatibility issues")
@@ -202,4 +202,6 @@ class XInterface:
 
 # Expose class for dynamic loading and register interface
 INTERFACE_CLASS = XInterface
-register_interface("x", XInterface())
+x_interface = XInterface()
+register_interface("x", x_interface)
+core_initializer.register_interface("x")


### PR DESCRIPTION
## Summary
- ensure Telethon userbot registers its client with the core registry
- register X interface instance and mark it active in the core initializer
- expose CLI interface start helper that registers itself with the core
- document how to build modular interfaces and action plugins with explicit action schemas and core registration

## Testing
- `./run_tests.sh` *(fails: No module named 'aiomysql')*
- `sphinx-build -b html docs docs/_build/html` *(fails: No matching distribution found for python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_689dd7a26680832880f530dda503d662