### PR TITLE
Handle interface message actions without plugin

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -13,8 +13,37 @@ from typing import Any, Dict, List, Tuple, Optional
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 
 
+# Cache for interface actions discovered via the interface registry
+_INTERFACE_ACTIONS: Dict[str, str] | None = None
+
+
+def _load_interface_actions() -> Dict[str, str]:
+    """Return a mapping of action_type -> interface_name from registered interfaces."""
+    global _INTERFACE_ACTIONS
+
+    try:
+        from core.core_initializer import INTERFACE_REGISTRY
+    except Exception as e:  # pragma: no cover - registry unavailable
+        log_warning(f"[action_parser] Unable to access INTERFACE_REGISTRY: {e}")
+        INTERFACE_REGISTRY = {}
+
+    actions: Dict[str, str] = {}
+    for name, iface in INTERFACE_REGISTRY.items():
+        try:
+            if hasattr(iface, "get_supported_actions"):
+                supported = iface.get_supported_actions()
+                if isinstance(supported, dict):
+                    for act in supported.keys():
+                        actions[str(act)] = name
+        except Exception as e:  # pragma: no cover - defensive
+            log_debug(f"[action_parser] Error inspecting interface {name}: {e}")
+
+    _INTERFACE_ACTIONS = actions
+    return actions
+
+
 def get_supported_action_types() -> set[str]:
-    """Return all supported action types discovered from plugins."""
+    """Return all supported action types discovered from plugins and interfaces."""
     supported_types: set[str] = set()
 
     try:
@@ -32,11 +61,17 @@ def get_supported_action_types() -> set[str]:
     except Exception as e:
         log_warning(f"[action_parser] Error discovering plugin action types: {e}")
 
+    # Include actions exposed by registered interfaces
+    try:
+        supported_types.update(_load_interface_actions().keys())
+    except Exception as e:  # pragma: no cover - defensive
+        log_debug(f"[action_parser] Error loading interface actions: {e}")
+
     return supported_types
 
 
-def _validate_payload_with_plugins(action_type: str, payload: dict, errors: List[str]) -> None:
-    """Validate payload using plugins that support the action type."""
+def _validate_payload(action_type: str, payload: dict, errors: List[str]) -> None:
+    """Validate payload using plugins or interfaces that support the action type."""
     try:
         for plugin in _load_action_plugins():
             # Check if this plugin supports the action type
@@ -54,7 +89,7 @@ def _validate_payload_with_plugins(action_type: str, payload: dict, errors: List
             except Exception as e:
                 log_debug(f"[action_parser] Error checking plugin support for {action_type}: {e}")
                 continue
-            
+
             if supports_action:
                 # Check if plugin has a validation method
                 if hasattr(plugin, "validate_payload"):
@@ -62,9 +97,13 @@ def _validate_payload_with_plugins(action_type: str, payload: dict, errors: List
                         plugin_errors = plugin.validate_payload(action_type, payload)
                         if plugin_errors and isinstance(plugin_errors, list):
                             errors.extend(plugin_errors)
-                            log_debug(f"[action_parser] Plugin {plugin.__class__.__name__} added {len(plugin_errors)} validation errors")
+                            log_debug(
+                                f"[action_parser] Plugin {plugin.__class__.__name__} added {len(plugin_errors)} validation errors"
+                            )
                     except Exception as e:
-                        log_warning(f"[action_parser] Error validating payload with plugin {plugin.__class__.__name__}: {e}")
+                        log_warning(
+                            f"[action_parser] Error validating payload with plugin {plugin.__class__.__name__}: {e}"
+                        )
                 elif hasattr(plugin, "validate_action"):
                     try:
                         # If plugin has validate_action, use that
@@ -72,14 +111,39 @@ def _validate_payload_with_plugins(action_type: str, payload: dict, errors: List
                         plugin_errors = plugin.validate_action(action_dict)
                         if plugin_errors and isinstance(plugin_errors, list):
                             errors.extend(plugin_errors)
-                            log_debug(f"[action_parser] Plugin {plugin.__class__.__name__} added {len(plugin_errors)} validation errors")
+                            log_debug(
+                                f"[action_parser] Plugin {plugin.__class__.__name__} added {len(plugin_errors)} validation errors"
+                            )
                     except Exception as e:
-                        log_warning(f"[action_parser] Error validating action with plugin {plugin.__class__.__name__}: {e}")
+                        log_warning(
+                            f"[action_parser] Error validating action with plugin {plugin.__class__.__name__}: {e}"
+                        )
                 else:
                     # Plugin doesn't have validation - that's OK, skip
-                    log_debug(f"[action_parser] Plugin {plugin.__class__.__name__} supports {action_type} but has no validation method")
+                    log_debug(
+                        f"[action_parser] Plugin {plugin.__class__.__name__} supports {action_type} but has no validation method"
+                    )
+
+        # Interface-based validation
+        iface_name = _load_interface_actions().get(action_type)
+        if iface_name:
+            try:
+                from core.core_initializer import INTERFACE_REGISTRY
+
+                iface = INTERFACE_REGISTRY.get(iface_name)
+                if iface and hasattr(iface, "validate_payload"):
+                    iface_errors = iface.validate_payload(action_type, payload)
+                    if iface_errors and isinstance(iface_errors, list):
+                        errors.extend(iface_errors)
+                        log_debug(
+                            f"[action_parser] Interface {iface_name} added {len(iface_errors)} validation errors"
+                        )
+            except Exception as e:  # pragma: no cover - defensive
+                log_warning(
+                    f"[action_parser] Error validating payload with interface {iface_name}: {e}"
+                )
     except Exception as e:
-        log_error(f"[action_parser] Error during plugin validation: {e}")
+        log_error(f"[action_parser] Error during payload validation: {e}")
 
 
 def validate_action(action: dict, context: dict = None, original_message=None) -> Tuple[bool, List[str]]:
@@ -114,21 +178,21 @@ def validate_action(action: dict, context: dict = None, original_message=None) -
     if not action_type:
         errors.append("Missing 'type'")
     else:
-        # Check if any plugin supports this action type
-        supported_by_plugin = False
+        # Check if any plugin or interface supports this action type
+        supported = False
         for plugin in _load_action_plugins():
             try:
                 if hasattr(plugin, "get_supported_action_types"):
                     if action_type in plugin.get_supported_action_types():
-                        supported_by_plugin = True
+                        supported = True
                         break
                 elif hasattr(plugin, "get_supported_actions"):
                     actions = plugin.get_supported_actions()
                     if isinstance(actions, dict) and action_type in actions:
-                        supported_by_plugin = True
+                        supported = True
                         break
                     elif isinstance(actions, (list, set, tuple)) and action_type in actions:
-                        supported_by_plugin = True
+                        supported = True
                         break
             except Exception as e:
                 log_debug(
@@ -136,9 +200,14 @@ def validate_action(action: dict, context: dict = None, original_message=None) -
                 )
                 continue
 
-        if not supported_by_plugin:
+        if not supported:
+            iface_actions = _load_interface_actions()
+            if action_type in iface_actions:
+                supported = True
+
+        if not supported:
             errors.append(
-                f"Unsupported type '{action_type}' - no plugin found to handle it"
+                f"Unsupported type '{action_type}' - no plugin or interface found to handle it"
             )
 
     payload = action.get("payload")
@@ -147,9 +216,9 @@ def validate_action(action: dict, context: dict = None, original_message=None) -
     elif not isinstance(payload, dict):
         errors.append("'payload' must be a dict")
 
-    # Dynamic validation - delegate to plugins that support this action type
+    # Dynamic validation - delegate to plugins or interfaces that support this action type
     if isinstance(payload, dict) and action_type in get_supported_action_types():
-        _validate_payload_with_plugins(action_type, payload, errors)
+        _validate_payload(action_type, payload, errors)
 
     return len(errors) == 0, errors
 
@@ -315,7 +384,35 @@ async def _handle_plugin_action(
     log_info(f"[action_parser] 🔍 Found {len(plugins)} plugins for action type '{action_type}'")
     
     if not plugins:
-        log_error(f"[action_parser] ❌ No plugin supports action type '{action_type}'")
+        log_info(
+            f"[action_parser] 📭 No plugin found for action type '{action_type}', attempting interface dispatch"
+        )
+
+        # Determine target interface from action or registry mapping
+        iface_name = iface_target or _load_interface_actions().get(action_type)
+        try:
+            from core.core_initializer import INTERFACE_REGISTRY
+
+            interface = INTERFACE_REGISTRY.get(iface_name) if iface_name else None
+            if interface and action_type.startswith("message") and hasattr(interface, "send_message"):
+                payload = action.get("payload", {})
+                log_info(
+                    f"[action_parser] ✉️ Dispatching message action to interface '{iface_name}'"
+                )
+                try:
+                    result = interface.send_message(payload, original_message)
+                    if inspect.iscoroutine(result):
+                        await result
+                    return None
+                except Exception as e:
+                    log_error(
+                        f"[action_parser] ❌ Error executing {action_type} via interface {iface_name}: {repr(e)}"
+                    )
+                return
+        except Exception as e:  # pragma: no cover - defensive
+            log_warning(f"[action_parser] Interface dispatch failed: {e}")
+
+        log_error(f"[action_parser] ❌ No plugin or interface supports action type '{action_type}'")
         return
     
     for plugin in plugins:

--- a/tests/test_action_validation.py
+++ b/tests/test_action_validation.py
@@ -5,6 +5,7 @@
 import sys
 import os
 import pytest
+import types
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -12,6 +13,54 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Mock environment to avoid config errors
 os.environ['BOTFATHER_TOKEN'] = 'test'
 os.environ['OPENAI_API_KEY'] = 'test'
+
+# Stub core.core_initializer with a minimal registry
+core_initializer_stub = types.ModuleType("core.core_initializer")
+core_initializer_stub.INTERFACE_REGISTRY = {}
+
+
+class CoreInitializer:
+    def __init__(self):
+        self.actions_block = {"available_actions": {}}
+
+    def _build_actions_block(self):  # pragma: no cover - minimal stub
+        return None
+
+
+def register_interface(name, obj):
+    core_initializer_stub.INTERFACE_REGISTRY[name] = obj
+
+
+core_initializer_stub.register_interface = register_interface
+core_initializer_stub.CoreInitializer = CoreInitializer
+sys.modules['core.core_initializer'] = core_initializer_stub
+
+
+class DummyTelegramInterface:
+    @staticmethod
+    def get_supported_actions():
+        return {
+            "message_telegram_bot": {
+                "required_fields": ["text", "target"],
+                "optional_fields": [],
+            }
+        }
+
+    @staticmethod
+    def validate_payload(action_type, payload):
+        errors = []
+        if not isinstance(payload.get("text"), str) or not payload.get("text"):
+            errors.append("payload.text must be a non-empty string")
+        if payload.get("target") is None:
+            errors.append("payload.target is required for message_telegram_bot action")
+        return errors
+
+    async def send_message(self, payload, original_message=None):
+        pass
+
+
+# Register dummy interface so action_parser knows about message_telegram_bot
+register_interface("telegram_bot", DummyTelegramInterface())
 
 from core.action_parser import validate_action
 


### PR DESCRIPTION
## Summary
- allow action parser to discover and validate message_* actions directly from registered interfaces
- remove redundant MessagePlugin and dispatch message actions to interfaces when no plugin exists
- update action validation test with a lightweight interface stub

## Testing
- `python tests/test_plugin_discovery.py`
- `python tests/test_action_validation.py`
- `python tests/test_auto_response.py`
- `python tests/test_target_validation_isolated.py`
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_689de6cf5a108328b3c8a7b02dde5c86