### PR TITLE
Sanitize prompts in core to handle non-serializable objects

### DIFF
--- a/core/json_utils.py
+++ b/core/json_utils.py
@@ -1,0 +1,30 @@
+import json
+from collections.abc import Mapping, Sequence
+
+
+def custom_json_encoder(obj):
+    """Fallback encoder that converts objects to dictionaries or strings."""
+    if hasattr(obj, "__dict__"):
+        return obj.__dict__
+    return str(obj)
+
+
+def dumps(data, **kwargs):
+    """Serialize ``data`` to JSON using the custom encoder."""
+    kwargs.setdefault("ensure_ascii", False)
+    return json.dumps(data, default=custom_json_encoder, **kwargs)
+
+
+def sanitize_for_json(obj):
+    """Recursively convert objects into JSON-serializable structures."""
+    if isinstance(obj, Mapping):
+        return {k: sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [sanitize_for_json(v) for v in obj]
+    try:
+        json.dumps(obj)
+        return obj
+    except TypeError:
+        if hasattr(obj, "__dict__"):
+            return sanitize_for_json(obj.__dict__)
+        return str(obj)

--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -2,27 +2,17 @@
 
 from core.config import get_active_llm, set_active_llm
 from core.prompt_engine import load_identity_prompt
-import json
 from core.prompt_engine import build_json_prompt
 import asyncio
 from types import SimpleNamespace
 from datetime import datetime
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from core.action_parser import parse_action
+from core.json_utils import dumps as json_dumps, sanitize_for_json
 
 # Plugin gestito centralmente in initialize_core_components
 plugin = None
 rekku_identity_prompt = None
-
-# Custom JSON encoder to handle non-serializable objects
-def custom_json_encoder(obj):
-    if hasattr(obj, '__dict__'):
-        return obj.__dict__
-    return str(obj)  # Fallback to string representation
-
-# Centralize JSON serialization with custom encoder
-def serialize_with_custom_encoder(data):
-    return json.dumps(data, ensure_ascii=False, default=custom_json_encoder)
 
 async def load_plugin(name: str, notify_fn=None):
     global plugin, rekku_identity_prompt
@@ -143,9 +133,10 @@ async def handle_incoming_message(bot, message, context_memory_or_prompt):
         )
         prompt = await build_json_prompt(message, context_memory_or_prompt)
 
+    prompt = sanitize_for_json(prompt)
     log_debug("🌐 JSON PROMPT built for the plugin:")
     try:
-        log_debug(serialize_with_custom_encoder(prompt))
+        log_debug(json_dumps(prompt))
     except Exception as e:
         log_error(f"Failed to serialize prompt: {e}")
 

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -2,8 +2,8 @@
 
 from core.rekku_tagging import extract_tags, expand_tags
 from core.db import get_conn
-import json
 from core.logging_utils import log_debug, log_info, log_warning, log_error
+from core.json_utils import dumps as json_dumps
 import aiomysql
 
 
@@ -80,8 +80,8 @@ async def build_json_prompt(message, context_memory) -> dict:
     input_section = {"type": "message", "payload": input_payload}
 
     # Debug output for both sections
-    log_debug("[json_prompt] context = " + json.dumps(context_section, ensure_ascii=False))
-    log_debug("[json_prompt] input = " + json.dumps(input_section, ensure_ascii=False))
+    log_debug("[json_prompt] context = " + json_dumps(context_section))
+    log_debug("[json_prompt] input = " + json_dumps(input_section))
 
     # Add JSON instructions to the prompt
     json_instructions = load_json_instructions()


### PR DESCRIPTION
## Summary
- add core JSON utilities to convert non-serializable objects into safe structures
- sanitize prompts centrally before passing to LLM engines
- log prompt sections with safe JSON dumping and remove engine-specific workaround

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'aiomysql', 'telegram', 'dotenv')*
- `pip install aiomysql` *(fails: Could not find a version that satisfies the requirement aiomysql due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1de7a5fcc8328ba46a0022634acbd