### PR TITLE
Refactor plugin discovery and logging

### DIFF
--- a/core/core_initializer.py
+++ b/core/core_initializer.py
@@ -58,30 +58,31 @@ class CoreInitializer:
     
     def _load_plugins(self):
         """Auto-discover and load all available plugins for validation and startup."""
-        # Note: This now actually loads and starts action plugins, not just validates them
-        
-        plugins_dir = Path(__file__).parent.parent / "plugins"
-        
-        if not plugins_dir.exists():
-            log_warning("[core_initializer] No plugins directory found")
-            return
-        
-        # Find all *_plugin.py files
-        plugin_files = list(plugins_dir.glob("*_plugin.py"))
-        
-        for plugin_file in plugin_files:
-            plugin_name = plugin_file.stem.replace("_plugin", "")
-            
-            # Skip __init__.py and other non-plugin files
-            if plugin_name.startswith("_"):
+        # Note: This now actually loads and starts action providers from
+        # plugins, LLM engines and interfaces. Files no longer need to follow a
+        # ``*_plugin.py`` naming convention.
+
+        root_dir = Path(__file__).parent.parent
+        search_dirs = ["plugins", "llm_engines", "interface"]
+
+        for base in search_dirs:
+            base_path = root_dir / base
+            if not base_path.exists():
                 continue
-                
-            try:
-                # Import and instantiate the plugin
-                import importlib
-                import asyncio
-                module = importlib.import_module(f"plugins.{plugin_name}_plugin")
-                
+
+            for py_file in base_path.rglob("*.py"):
+                if py_file.name == "__init__.py" or py_file.name.startswith("_"):
+                    continue
+
+                module_name = ".".join(py_file.relative_to(root_dir).with_suffix("").parts)
+
+                try:
+                    module = importlib.import_module(module_name)
+                except Exception as e:
+                    log_warning(f"[core_initializer] ⚠️ Failed to import {module_name}: {e}")
+                    self.startup_errors.append(f"Module {module_name}: {e}")
+                    continue
+
                 if hasattr(module, "PLUGIN_CLASS"):
                     plugin_class = getattr(module, "PLUGIN_CLASS")
                     # Basic validation that it's a proper plugin class
@@ -89,50 +90,40 @@ class CoreInitializer:
                         try:
                             # Create instance and start it
                             instance = plugin_class()
-                            
+
                             # Start the plugin if it has a start method
                             if hasattr(instance, "start"):
                                 try:
                                     if asyncio.iscoroutinefunction(instance.start):
-                                        # Try to get the running loop and schedule start
                                         try:
                                             loop = asyncio.get_running_loop()
                                             if loop and loop.is_running():
                                                 loop.create_task(instance.start())
-                                                log_info(f"[core_initializer] Started async plugin: {plugin_name}")
+                                                log_info(f"[core_initializer] Started async plugin: {module_name}")
                                             else:
-                                                log_warning(f"[core_initializer] No running loop for async plugin: {plugin_name}")
-                                                # Store for later startup
+                                                log_warning(f"[core_initializer] No running loop for async plugin: {module_name}")
                                                 if not hasattr(self, '_pending_async_plugins'):
                                                     self._pending_async_plugins = []
-                                                self._pending_async_plugins.append((plugin_name, instance))
+                                                self._pending_async_plugins.append((module_name, instance))
                                         except RuntimeError:
-                                            log_warning(f"[core_initializer] No event loop for async plugin: {plugin_name}")
-                                            # Store for later startup
+                                            log_warning(f"[core_initializer] No event loop for async plugin: {module_name}")
                                             if not hasattr(self, '_pending_async_plugins'):
                                                 self._pending_async_plugins = []
-                                            self._pending_async_plugins.append((plugin_name, instance))
+                                            self._pending_async_plugins.append((module_name, instance))
                                     else:
                                         instance.start()
-                                        log_info(f"[core_initializer] Started sync plugin: {plugin_name}")
+                                        log_info(f"[core_initializer] Started sync plugin: {module_name}")
                                 except Exception as e:
-                                    log_error(f"[core_initializer] Error starting plugin {plugin_name}: {repr(e)}")
+                                    log_error(f"[core_initializer] Error starting plugin {module_name}: {repr(e)}")
                             else:
-                                log_debug(f"[core_initializer] Plugin {plugin_name} has no start method")
-                                    
+                                log_debug(f"[core_initializer] Plugin {module_name} has no start method")
+
                         except Exception as e:
-                            log_error(f"[core_initializer] Failed to start plugin {plugin_name}: {repr(e)}")
-                            self.startup_errors.append(f"Plugin {plugin_name}: {e}")
+                            log_error(f"[core_initializer] Failed to start plugin {module_name}: {repr(e)}")
+                            self.startup_errors.append(f"Plugin {module_name}: {e}")
                     else:
-                        log_warning(f"[core_initializer] ⚠️ Plugin {plugin_name} doesn't implement action interface")
-                        self.startup_errors.append(f"Plugin {plugin_name}: Missing action interface")
-                else:
-                    log_warning(f"[core_initializer] ⚠️ Plugin {plugin_name} missing PLUGIN_CLASS")
-                    self.startup_errors.append(f"Plugin {plugin_name}: Missing PLUGIN_CLASS")
-                    
-            except Exception as e:
-                log_warning(f"[core_initializer] ⚠️ Failed to load plugin {plugin_name}: {e}")
-                self.startup_errors.append(f"Plugin {plugin_name}: {e}")
+                        log_warning(f"[core_initializer] ⚠️ Plugin {module_name} doesn't implement action interface")
+                        self.startup_errors.append(f"Plugin {module_name}: Missing action interface")
     
     def _discover_interfaces(self):
         """Auto-discover active interfaces by checking running processes/modules."""

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -10,8 +10,10 @@ core system.
 .. _Read the Docs: https://rekku.readthedocs.io
 
 1. **Create the module**
-   Place a new ``*.py`` file under the ``interface/`` directory.  Removing the
-   file later cleanly removes the interface from Rekku.
+   Place a new ``*.py`` file under the ``interface/`` directory.  The core now
+   imports all modules in ``interface/``, ``plugins/`` and ``llm_engines/``
+   recursively, so no special naming convention is required. Removing the file
+   later cleanly removes the interface from Rekku.
 
 2. **Declare actions**
    Implement ``get_supported_actions`` on the interface class.  The method should

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -28,8 +28,10 @@ Event
 The ``event`` plugin stores scheduled reminders in a MariaDB table. A background
 scheduler checks for due events and sends them back to Rekku when the time comes.
 
-All plugins register themselves using ``register_plugin`` and notify the core
-initializer with ``core_initializer.register_plugin``.
+All Python modules under ``plugins/``, ``llm_engines/`` and ``interface/`` are
+imported recursively on startup. Plugin files no longer need a special naming
+scheme. Each plugin registers itself using ``register_plugin`` and notifies the
+core initializer with ``core_initializer.register_plugin``.
 
 Reddit Interface
 ----------------

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -12,7 +12,6 @@ class DiscordInterface:
     def __init__(self, bot_token):
         # Initialize Discord client
         register_interface("discord_bot", self)
-        core_initializer.register_interface("discord_bot")
         log_info("[discord_interface] Registered DiscordInterface")
 
     @staticmethod
@@ -36,6 +35,7 @@ class DiscordInterface:
             }
         }
 
+    @staticmethod
     def get_prompt_instructions(action_name: str) -> dict:
         if action_name == "message_discord_bot":
             return {

--- a/llm_engines/google_cli.py
+++ b/llm_engines/google_cli.py
@@ -4,7 +4,8 @@ import subprocess
 import json
 from core.ai_plugin_base import AIPluginBase
 from core.logging_utils import log_debug, log_info, log_warning, log_error
-from core.config import set_notifier, GEMINI_API_KEY
+from core.notifier import set_notifier
+from core.config import GEMINI_API_KEY
 
 class GoogleCLIPlugin(AIPluginBase):
     """

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -177,8 +177,10 @@ def _send_text_to_textarea(driver, textarea, text: str) -> None:
     """Inject ``text`` into the ChatGPT prompt area via JavaScript."""
     clean_text = strip_non_bmp(text)
     log_debug(f"[DEBUG] Length before sending: {len(clean_text)}")
-    preview = clean_text[:120] + ("..." if len(clean_text) > 120 else "")
-    log_debug(f"[DEBUG] Text preview: {preview}")
+    # Log the full text to aid debugging and ensure the JSON is not truncated
+    # in logs. This may produce very long lines but provides complete
+    # visibility into the prompt content.
+    log_debug(f"[DEBUG] Text to send: {clean_text}")
 
     tag = (textarea.tag_name or "").lower()
     prop = "value" if tag in {"textarea", "input"} else "textContent"


### PR DESCRIPTION
## Summary
- Avoid truncating ChatGPT prompts in Selenium driver
- Recursively load plugins and interfaces from all action directories
- Document new recursive action discovery for plugins and interfaces

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'aiomysql')*


------
https://chatgpt.com/codex/tasks/task_e_68a3383acfcc832887032e044d6f79f1