### PR TITLE
Notify trainer on terminal actions

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -588,17 +588,28 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
 
     processed_actions = []
     collected_errors = []
+    action_outputs: List[Dict[str, Any]] = []
+    terminal_seen = False
 
     for idx, action in enumerate(actions):
         try:
+            action_type = action.get("type")
+
+            # Halt processing of subsequent non-terminal actions until the LLM
+            # has seen the outputs from executed terminal commands.
+            if terminal_seen and action_type != "terminal":
+                log_info(
+                    "[action_parser] ⏸️ Waiting for LLM response before executing remaining actions"
+                )
+                break
+
             valid, errors = validate_action(action, context, original_message)
             if not valid:
                 error_msg = f"Invalid action {idx}: {errors}"
                 log_warning(f"[action_parser] Skipping {error_msg}")
                 collected_errors.append(error_msg)
                 continue
-            
-            action_type = action.get('type')
+
             log_debug(f"[action_parser] Running action {idx}: {action_type}")
             result = await run_action(action, context, bot, original_message)
 
@@ -608,13 +619,16 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
             else:
                 processed_actions.append(action)
 
-            # Halt further actions after a terminal command to wait for LLM response
-            if action_type == "terminal":
-                log_info(
-                    "[action_parser] ⏸️ Terminal action executed; waiting for LLM response before processing further actions"
-                )
-                break
-                
+                if action_type == "terminal" and isinstance(result, str):
+                    terminal_seen = True
+                    action_outputs.append(
+                        {
+                            "type": "terminal",
+                            "command": action.get("payload", {}).get("command", ""),
+                            "output": result,
+                        }
+                    )
+
         except Exception as e:
             error_msg = f"Error executing action {idx}: {repr(e)}"
             log_error(f"[action_parser] {error_msg}")
@@ -641,10 +655,39 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
                 f"[action_parser] Failed to clear processing flag for event {event_id}: {e}"
             )
 
+    if action_outputs:
+        interface_name = context.get("interface", "telegram_bot")
+        if interface_name == "telegram":
+            interface_name = "telegram_bot"
+
+        response_context = {
+            "chat_id": getattr(original_message, "chat_id", None),
+            "message_id": getattr(original_message, "message_id", None),
+            "interface_name": interface_name,
+            "message_thread_id": getattr(original_message, "message_thread_id", None),
+        }
+
+        try:
+            from core.auto_response import request_llm_delivery
+
+            await request_llm_delivery(
+                action_outputs=action_outputs,
+                original_context=response_context,
+                action_type="terminal",
+            )
+        except Exception as e:
+            log_warning(
+                f"[action_parser] Failed to request LLM delivery for action outputs: {e}"
+            )
+
     if collected_errors:
         await corrector(collected_errors, actions, bot, original_message)
 
-    return {"processed": processed_actions, "errors": collected_errors}
+    return {
+        "processed": processed_actions,
+        "errors": collected_errors,
+        "action_outputs": action_outputs,
+    }
 
 
 async def parse_action(action: dict, bot, message):

--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -598,14 +598,22 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
                 collected_errors.append(error_msg)
                 continue
             
-            log_debug(f"[action_parser] Running action {idx}: {action.get('type')}")
+            action_type = action.get('type')
+            log_debug(f"[action_parser] Running action {idx}: {action_type}")
             result = await run_action(action, context, bot, original_message)
-            
+
             # Check if run_action returned error info
             if isinstance(result, dict) and "error" in result:
                 collected_errors.append(result["error"])
             else:
                 processed_actions.append(action)
+
+            # Halt further actions after a terminal command to wait for LLM response
+            if action_type == "terminal":
+                log_info(
+                    "[action_parser] ⏸️ Terminal action executed; waiting for LLM response before processing further actions"
+                )
+                break
                 
         except Exception as e:
             error_msg = f"Error executing action {idx}: {repr(e)}"

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -88,14 +88,19 @@ class AutoResponseSystem:
             # Get interface instance dynamically without hardcoding
             from core.core_initializer import INTERFACE_REGISTRY
 
-            bot = INTERFACE_REGISTRY.get(interface_name)
-            if not bot:
+            interface = INTERFACE_REGISTRY.get(interface_name)
+            if not interface:
                 log_error(
                     f"[auto_response] No interface '{interface_name}' available"
                 )
                 return
-            
-            # Enqueue the LLM request
+
+            # Use the raw Telegram Bot instance if the interface wraps one
+            bot = getattr(interface, "bot", interface)
+
+            # Enqueue the LLM request using the bot so downstream handlers
+            # receive the expected python-telegram-bot API object rather than
+            # the interface wrapper (which has a different send_message signature).
             await enqueue(bot, mock_message, context_memory, priority=True)
             
         except Exception as e:

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -7,6 +7,7 @@ Used when interfaces need to report results back through the LLM instead of dire
 import asyncio
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from typing import Dict, Any, Optional
+from datetime import datetime
 
 
 class AutoResponseSystem:
@@ -56,6 +57,15 @@ class AutoResponseSystem:
             mock_message.from_user.id = chat_id
             mock_message.from_user.username = "auto_response"
             mock_message.from_user.first_name = "AutoResponse"
+            mock_message.from_user.full_name = "AutoResponse"
+
+            # Message metadata expected by downstream handlers
+            mock_message.date = datetime.utcnow()
+            mock_message.reply_to_message = None
+            mock_message.message_thread_id = original_context.get(
+                "message_thread_id"
+            )
+
             # Provide chat structure expected by message_queue.enqueue
             mock_message.chat = SimpleNamespace()
             mock_message.chat.id = chat_id

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -43,13 +43,26 @@ class AutoResponseSystem:
             # Create a mock message object for the LLM request
             from types import SimpleNamespace
             mock_message = SimpleNamespace()
+            # Basic identifiers
             mock_message.chat_id = chat_id
             mock_message.message_id = message_id or 0
-            mock_message.text = f"Auto-response for {action_type}: {command}" if command else f"Auto-response for {action_type}"
+            mock_message.text = (
+                f"Auto-response for {action_type}: {command}"
+                if command
+                else f"Auto-response for {action_type}"
+            )
+            # Populate minimal from_user info
             mock_message.from_user = SimpleNamespace()
             mock_message.from_user.id = chat_id
             mock_message.from_user.username = "auto_response"
             mock_message.from_user.first_name = "AutoResponse"
+            # Provide chat structure expected by message_queue.enqueue
+            mock_message.chat = SimpleNamespace()
+            mock_message.chat.id = chat_id
+            mock_message.chat.title = None
+            mock_message.chat.username = None
+            mock_message.chat.first_name = "AutoResponse"
+            mock_message.chat.type = "private"
             
             # Create context memory with the output and instructions
             context_memory = {

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -130,9 +130,15 @@ class ChatLinkStore:
         return rows_deleted
 from core.telegram_utils import safe_send
 
-# Fallback per notify_trainer se non disponibile
-def notify_trainer(trainer_id, text):
-    log_warning(f"[notify_trainer fallback] trainer_id={trainer_id}: {text}")
+# Fallback per notify_trainer se il modulo core.notifier non è disponibile
+def notify_trainer(message: str) -> None:
+    """Best-effort trainer notification used during tests.
+
+    The real ``notify_trainer`` utility accepts a single message argument, so
+    the fallback must mirror that signature to avoid ``TypeError`` when the
+    caller provides just the message text.
+    """
+    log_warning(f"[notify_trainer fallback] {message}")
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/plugins/terminal.py
+++ b/plugins/terminal.py
@@ -185,7 +185,8 @@ class TerminalPlugin(AIPluginBase):
         action_type = action.get("type")
         payload = action.get("payload", {})
         command = payload.get("command", "")
-        persistent_session = payload.get("persistent_session", False)
+        # Default to persistent sessions so the LLM can interact like a user
+        persistent_session = payload.get("persistent_session", True)
 
         if not command:
             log_warning(f"[terminal] No command provided for {action_type} action")
@@ -233,9 +234,13 @@ class TerminalPlugin(AIPluginBase):
                     command=command
                 )
 
-                log_info(f"[terminal] Requested LLM delivery of {action_type} output to chat {original_message.chat_id}")
+                log_info(
+                    f"[terminal] Requested LLM delivery of {action_type} output to chat {original_message.chat_id}"
+                )
             else:
                 log_warning("[terminal] No original_message context for auto-response")
+
+            return output
 
         except Exception as e:
             log_error(f"[terminal] Error executing {action_type} command '{command}': {e}")
@@ -264,6 +269,7 @@ class TerminalPlugin(AIPluginBase):
                     action_type=f"{action_type}_error",
                     command=command
                 )
+            return f"Error executing command '{command}': {str(e)}"
 
     def get_target(self, trainer_message_id):
         return None

--- a/plugins/terminal.py
+++ b/plugins/terminal.py
@@ -256,3 +256,4 @@ class TerminalPlugin(AIPluginBase):
 
 
 PLUGIN_CLASS = TerminalPlugin
+

--- a/tests/test_auto_response.py
+++ b/tests/test_auto_response.py
@@ -21,6 +21,8 @@ def test_request_llm_response_builds_chat(monkeypatch):
         captured['chat'] = getattr(message, 'chat', None)
         captured['chat_id'] = getattr(message.chat, 'id', None)
         captured['text'] = message.text
+        captured['full_name'] = getattr(message.from_user, 'full_name', None)
+        captured['date'] = getattr(message, 'date', None)
 
     sys.modules['core.message_queue'] = SimpleNamespace(enqueue=fake_enqueue)
 
@@ -37,3 +39,5 @@ def test_request_llm_response_builds_chat(monkeypatch):
     assert captured['chat'] is not None
     assert captured['chat_id'] == 42
     assert 'terminal' in captured['text']
+    assert captured['full_name'] == 'AutoResponse'
+    assert captured['date'] is not None

--- a/tests/test_auto_response.py
+++ b/tests/test_auto_response.py
@@ -11,13 +11,14 @@ from core.auto_response import AutoResponseSystem
 def test_request_llm_response_builds_chat(monkeypatch):
     # Provide fake interface registry without importing heavy modules
     fake_core_initializer = SimpleNamespace(
-        INTERFACE_REGISTRY={'telegram_bot': SimpleNamespace()}
+        INTERFACE_REGISTRY={'telegram_bot': SimpleNamespace(bot='INNER_BOT')}
     )
     sys.modules['core.core_initializer'] = fake_core_initializer
 
     captured = {}
 
     async def fake_enqueue(bot, message, context_memory, priority=True):
+        captured['bot'] = bot
         captured['chat'] = getattr(message, 'chat', None)
         captured['chat_id'] = getattr(message.chat, 'id', None)
         captured['text'] = message.text
@@ -36,6 +37,7 @@ def test_request_llm_response_builds_chat(monkeypatch):
         )
     )
 
+    assert captured['bot'] == 'INNER_BOT'
     assert captured['chat'] is not None
     assert captured['chat_id'] == 42
     assert 'terminal' in captured['text']

--- a/tests/test_auto_response.py
+++ b/tests/test_auto_response.py
@@ -1,84 +1,39 @@
-#!/usr/bin/env python3
-"""Test per verificare il nuovo sistema di auto-response."""
+import sys, os
+from types import SimpleNamespace
+import asyncio
 
-import sys
-import os
-
-# Add parent directory to path
+# Ensure repository root in path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Mock environment to avoid config errors
-os.environ['BOTFATHER_TOKEN'] = 'test'
-os.environ['OPENAI_API_KEY'] = 'test'
+from core.auto_response import AutoResponseSystem
 
-def test_auto_response_system():
-    print("🧪 Testing Auto-Response System...")
-    print("=" * 60)
-    
-    try:
-        from core.auto_response import request_llm_delivery
-        from types import SimpleNamespace
-        
-        print("✅ Auto-response module imported successfully")
-        
-        # Test context setup
-        original_context = {
-            'chat_id': 12345,
-            'message_id': 67890,
-            'interface_name': 'telegram_bot',
-            'original_command': 'ls -la',
-            'action_type': 'bash'
-        }
-        
-        sample_output = """total 48
-drwxr-xr-x  8 user user 4096 Aug  3 09:25 .
-drwxr-xr-x  3 user user 4096 Aug  1 10:00 ..
--rw-r--r--  1 user user  123 Aug  3 09:20 test.txt
-drwxr-xr-x  2 user user 4096 Aug  2 15:30 logs"""
-        
-        print("\n📋 Test context:")
-        print(f"   Chat ID: {original_context['chat_id']}")
-        print(f"   Command: {original_context['original_command']}")
-        print(f"   Output length: {len(sample_output)} chars")
-        
-        # Test the function signature (without actually calling it due to dependencies)
-        print("\n🔍 Testing function signature...")
-        try:
-            # This would normally trigger the LLM request
-            # await request_llm_delivery(
-            #     output=sample_output,
-            #     original_context=original_context,
-            #     action_type="bash",
-            #     command="ls -la"
-            # )
-            print("✅ Function signature is correct")
-        except Exception as e:
-            print(f"🚨 Function signature error: {e}")
-        
-        print("\n📦 Testing TerminalPlugin integration...")
-        
-        # Test that TerminalPlugin can import the auto-response
-        try:
-            # This simulates what TerminalPlugin will do
-            print("✅ TerminalPlugin can import auto_response module")
-        except Exception as e:
-            print(f"🚨 TerminalPlugin integration error: {e}")
-            
-    except ImportError as e:
-        print(f"💥 Import error: {e}")
-        import traceback
-        traceback.print_exc()
-    
-    print("\n" + "=" * 60)
-    print("🎉 Auto-Response System test completed!")
-    print("\n🎯 Expected flow:")
-    print("   1. User: 'rekku fammi df -h'")
-    print("   2. LLM generates: bash action")
-    print("   3. TerminalPlugin executes command")
-    print("   4. TerminalPlugin calls request_llm_delivery()")
-    print("   5. LLM gets output + context")
-    print("   6. LLM generates: message_telegram_bot action")
-    print("   7. User receives formatted response")
 
-if __name__ == "__main__":
-    test_auto_response_system()
+def test_request_llm_response_builds_chat(monkeypatch):
+    # Provide fake interface registry without importing heavy modules
+    fake_core_initializer = SimpleNamespace(
+        INTERFACE_REGISTRY={'telegram_bot': SimpleNamespace()}
+    )
+    sys.modules['core.core_initializer'] = fake_core_initializer
+
+    captured = {}
+
+    async def fake_enqueue(bot, message, context_memory, priority=True):
+        captured['chat'] = getattr(message, 'chat', None)
+        captured['chat_id'] = getattr(message.chat, 'id', None)
+        captured['text'] = message.text
+
+    sys.modules['core.message_queue'] = SimpleNamespace(enqueue=fake_enqueue)
+
+    auto = AutoResponseSystem()
+    asyncio.run(
+        auto.request_llm_response(
+            output='done',
+            original_context={'chat_id': 42, 'message_id': 5, 'interface_name': 'telegram_bot'},
+            action_type='terminal',
+            command='ls'
+        )
+    )
+
+    assert captured['chat'] is not None
+    assert captured['chat_id'] == 42
+    assert 'terminal' in captured['text']

--- a/tests/test_terminal_plugin.py
+++ b/tests/test_terminal_plugin.py
@@ -12,10 +12,10 @@ from plugins.terminal import TerminalPlugin
 async def test_execute_action_notifies_and_normalizes(monkeypatch):
     plugin = TerminalPlugin()
 
-    async def fake_run_single_command(cmd):
+    async def fake_send_command(cmd):
         return "result"
 
-    monkeypatch.setattr(plugin, "_run_single_command", fake_run_single_command)
+    monkeypatch.setattr(plugin, "_send_command", fake_send_command)
 
     notified = {}
     def fake_notify(msg):
@@ -33,8 +33,9 @@ async def test_execute_action_notifies_and_normalizes(monkeypatch):
     context = {"interface": "telegram"}
     message = SimpleNamespace(chat_id=1, message_id=2)
 
-    await plugin.execute_action(action, context, bot=None, original_message=message)
+    output = await plugin.execute_action(action, context, bot=None, original_message=message)
 
     assert captured['interface'] == 'telegram_bot'
     assert 'echo hi' in notified['msg']
     assert 'result' in notified['msg']
+    assert output == 'result'

--- a/tests/test_terminal_plugin.py
+++ b/tests/test_terminal_plugin.py
@@ -1,0 +1,40 @@
+import sys
+import os
+from types import SimpleNamespace
+import pytest
+
+# Ensure repository root is in path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from plugins.terminal import TerminalPlugin
+
+@pytest.mark.asyncio
+async def test_execute_action_notifies_and_normalizes(monkeypatch):
+    plugin = TerminalPlugin()
+
+    async def fake_run_single_command(cmd):
+        return "result"
+
+    monkeypatch.setattr(plugin, "_run_single_command", fake_run_single_command)
+
+    notified = {}
+    def fake_notify(msg):
+        notified['msg'] = msg
+    monkeypatch.setattr("plugins.terminal.notify_trainer", fake_notify)
+
+    captured = {}
+    async def fake_request_llm_delivery(output, original_context, action_type, command):
+        captured['interface'] = original_context.get('interface_name')
+        captured['output'] = output
+        captured['command'] = command
+    monkeypatch.setattr("core.auto_response.request_llm_delivery", fake_request_llm_delivery)
+
+    action = {"type": "terminal", "payload": {"command": "echo hi"}}
+    context = {"interface": "telegram"}
+    message = SimpleNamespace(chat_id=1, message_id=2)
+
+    await plugin.execute_action(action, context, bot=None, original_message=message)
+
+    assert captured['interface'] == 'telegram_bot'
+    assert 'echo hi' in notified['msg']
+    assert 'result' in notified['msg']


### PR DESCRIPTION
## Summary
- notify trainer of executed terminal commands and results
- normalize terminal interface name to `telegram_bot` for auto-response
- test terminal plugin notification and interface mapping

## Testing
- `./run_tests.sh` *(fails: No module named 'aiomysql')*

------
https://chatgpt.com/codex/tasks/task_e_68a402a4cffc832892fa055592c8e4b8