### PR TITLE
feat: move chat_link actions into core

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -71,30 +71,15 @@ async def corrector(errors: list, failed_actions: list, bot, message):
     retry_count = _increment_retry(message)
 
     error_summary = "\n".join([f"- {err}" for err in errors[:5]])
-    failed_actions_json = json.dumps(failed_actions, indent=2, ensure_ascii=False)
 
-    # Build JSON structure reminder
-    try:
-        from core.core_initializer import core_initializer
-
-        actions_block = core_initializer.actions_block.get("available_actions", {})
-    except Exception as e:
-        log_warning(f"[corrector] Failed to load actions block: {e}")
-        actions_block = {}
-
-    instructions = load_json_instructions()
-    json_structure = json.dumps(
-        {"instructions": instructions, "actions": actions_block},
-        ensure_ascii=False,
-        indent=2,
+    message_text = (
+        f"{error_summary}\n"
+        "Please repeat your previous message, corrected."
     )
-
-    correction_prompt = (
-        f"Your JSON is invalid. The error is: {error_summary}\n"
-        "Please repeat the previous message, corrected.\n\n"
-        "Here is a reminder of the JSON structure:\n"
-        f"{json_structure}\n"
-    )
+    correction_payload = {
+        "system_message": {"type": "error", "message": message_text}
+    }
+    correction_prompt = json.dumps(correction_payload, ensure_ascii=False)
 
     log_warning(f"[corrector] {error_summary}")
     log_info(

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -16,8 +16,8 @@ class AutoResponseSystem:
         self._pending_responses = {}
     
     async def request_llm_response(
-        self, 
-        output: str, 
+        self,
+        output: str,
         original_context: Dict[str, Any],
         action_type: str,
         command: str = None
@@ -51,16 +51,13 @@ class AutoResponseSystem:
             mock_message.from_user.username = "auto_response"
             mock_message.from_user.first_name = "AutoResponse"
             
-            # Create context memory with the output and instructions
-            context_memory = {
-                "system_instruction": f"You executed a {action_type} command and got output. Please format and deliver this output to the user.",
-                "command_executed": command,
-                "command_output": output,
-                "delivery_instructions": f"Send the output back to chat {chat_id} using message_{interface_name} action. Format it nicely.",
-                "suggested_response": f"Here's the output from your {action_type} command:\n\n```\n{output}\n```"
+            system_payload = {
+                "system_message": {"type": "output", "message": output}
             }
-            
-            log_info(f"[auto_response] Requesting LLM to deliver {action_type} output to chat {chat_id}")
+
+            log_info(
+                f"[auto_response] Requesting LLM to deliver {action_type} output to chat {chat_id}"
+            )
             
             # Get interface instance dynamically without hardcoding
             from core.core_initializer import INTERFACE_REGISTRY
@@ -73,7 +70,14 @@ class AutoResponseSystem:
                 return
             
             # Enqueue the LLM request
-            await enqueue(bot, mock_message, context_memory, priority=True)
+            import json
+
+            await enqueue(
+                bot,
+                mock_message,
+                json.dumps(system_payload, ensure_ascii=False),
+                priority=True,
+            )
             
         except Exception as e:
             log_error(f"[auto_response] Failed to request LLM response: {e}")
@@ -112,27 +116,36 @@ async def request_llm_delivery(
     # Handle new calling pattern (interface style)
     if message is not None or interface is not None:
         try:
-            from core.message_queue import enqueue
             import core.plugin_instance as plugin_instance
-            
+
             log_info(f"[auto_response] Processing {reason or 'autonomous'} request")
-            
+
             # If we have a message, use it directly with plugin_instance
+            import json
+
+            if isinstance(context, dict) and context.get("input", {}).get("type") == "event":
+                system_payload = {
+                    "system_message": {"type": "event", "message": context}
+                }
+            else:
+                system_payload = {
+                    "system_message": {"type": "output", "message": context}
+                }
+
+            payload_json = json.dumps(system_payload, ensure_ascii=False)
+
             if message is not None:
-                await plugin_instance.handle_incoming_message(
-                    interface, message, context or {}
-                )
+                await plugin_instance.handle_incoming_message(interface, message, payload_json)
             else:
                 # For interface-only requests, create synthetic message
                 from types import SimpleNamespace
+
                 mock_message = SimpleNamespace()
                 mock_message.chat_id = -1  # Default chat
                 mock_message.message_id = 0
                 mock_message.text = f"Auto-generated message for {reason}"
-                
-                await plugin_instance.handle_incoming_message(
-                    interface, mock_message, context or {}
-                )
+
+                await plugin_instance.handle_incoming_message(interface, mock_message, payload_json)
                 
         except Exception as e:
             log_error(f"[auto_response] Failed to process {reason}: {e}")

--- a/core/chat_link_actions.py
+++ b/core/chat_link_actions.py
@@ -1,0 +1,74 @@
+"""Core actions for managing chat link metadata."""
+
+from core.logging_utils import log_info, log_warning, log_error
+from core.core_initializer import register_plugin
+from core.chat_link_store import ChatLinkStore
+
+
+class ChatLinkActions:
+    """Expose actions for updating chat and thread names."""
+
+    def __init__(self) -> None:
+        self.store = ChatLinkStore()
+        register_plugin("chat_link", self)
+        log_info("[chat_link_actions] Registered core chat_link actions")
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def get_supported_action_types():
+        return ["update_chat_name"]
+
+    @staticmethod
+    def get_supported_actions():
+        return {
+            "update_chat_name": {
+                "description": "Aggiorna il nome della chat o del thread per un chat link esistente.",
+                "required_fields": ["chat_id"],
+                "optional_fields": ["message_thread_id", "chat_name", "message_thread_name"],
+            }
+        }
+
+    @staticmethod
+    def validate_payload(action_type: str, payload: dict):
+        errors = []
+        if action_type == "update_chat_name":
+            if not payload.get("chat_id"):
+                errors.append("chat_id is required")
+            if not payload.get("chat_name") and not payload.get("message_thread_name"):
+                errors.append("chat_name or message_thread_name required")
+        return errors
+
+    async def execute_action(self, action: dict, context: dict, bot, original_message):
+        action_type = action.get("type")
+        if action_type != "update_chat_name":
+            return None
+
+        payload = action.get("payload", {})
+        chat_id = payload.get("chat_id")
+        message_thread_id = payload.get("message_thread_id")
+        chat_name = payload.get("chat_name")
+        thread_name = payload.get("message_thread_name")
+
+        try:
+            updated = await self.store.update_names(
+                chat_id,
+                message_thread_id,
+                chat_name=chat_name,
+                message_thread_name=thread_name,
+            )
+            if updated:
+                log_info(
+                    f"[chat_link_actions] Updated chat link names for chat_id={chat_id}, thread_id={message_thread_id}"
+                )
+            else:
+                log_warning("[chat_link_actions] No chat link updated")
+        except Exception as e:  # pragma: no cover - logging only
+            log_error(f"[chat_link_actions] Error updating chat names: {e}")
+            return {"error": str(e)}
+        return {"updated": updated}
+
+
+# Instantiate and register on import
+ChatLinkActions()
+
+__all__ = ["ChatLinkActions"]

--- a/core/chat_link_actions.py
+++ b/core/chat_link_actions.py
@@ -22,9 +22,9 @@ class ChatLinkActions:
     def get_supported_actions():
         return {
             "update_chat_name": {
-                "description": "Aggiorna il nome della chat o del thread per un chat link esistente.",
+                "description": "Aggiorna i nomi della chat e del thread usando i dati dell'interfaccia.",
                 "required_fields": ["chat_id"],
-                "optional_fields": ["message_thread_id", "chat_name", "message_thread_name"],
+                "optional_fields": ["message_thread_id"],
             }
         }
 
@@ -34,8 +34,6 @@ class ChatLinkActions:
         if action_type == "update_chat_name":
             if not payload.get("chat_id"):
                 errors.append("chat_id is required")
-            if not payload.get("chat_name") and not payload.get("message_thread_name"):
-                errors.append("chat_name or message_thread_name required")
         return errors
 
     async def execute_action(self, action: dict, context: dict, bot, original_message):
@@ -46,15 +44,11 @@ class ChatLinkActions:
         payload = action.get("payload", {})
         chat_id = payload.get("chat_id")
         message_thread_id = payload.get("message_thread_id")
-        chat_name = payload.get("chat_name")
-        thread_name = payload.get("message_thread_name")
-
         try:
-            updated = await self.store.update_names(
+            updated = await self.store.update_names_from_resolver(
                 chat_id,
                 message_thread_id,
-                chat_name=chat_name,
-                message_thread_name=thread_name,
+                bot=bot,
             )
             if updated:
                 log_info(

--- a/core/chat_link_store.py
+++ b/core/chat_link_store.py
@@ -1,0 +1,284 @@
+"""Store and resolve mappings between external chats and ChatGPT conversations."""
+
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+
+import aiomysql
+
+from core.logging_utils import log_debug, log_error, log_warning
+from core.db import get_conn
+
+
+class ChatLinkStore:
+    """Persistence layer for chat -> ChatGPT conversation links.
+
+    Supports optional tracking of chat and thread names to allow lookup by
+    human-readable identifiers.
+    """
+
+    def __init__(self) -> None:
+        self._table_ensured = False
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _normalize_thread_id(self, message_thread_id: Optional[int | str]) -> str:
+        """Return ``message_thread_id`` as a non-null string."""
+        return str(message_thread_id) if message_thread_id is not None else "0"
+
+    def _normalize_name(self, value: Optional[str]) -> Optional[str]:
+        """Return a cleaned name or ``None`` if not provided."""
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value if value else None
+
+    async def _ensure_table(self) -> None:
+        """Create the ``chatgpt_links`` table and new columns if necessary."""
+        if self._table_ensured:
+            return
+        conn = await get_conn()
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS chatgpt_links (
+                    chat_id TEXT NOT NULL,
+                    message_thread_id TEXT,
+                    link VARCHAR(2048),
+                    chat_name TEXT,
+                    message_thread_name TEXT,
+                    PRIMARY KEY (chat_id(255), message_thread_id(255))
+                )
+                """
+            )
+            # Ensure new columns exist for older installations
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS chat_name TEXT"
+                )
+            except Exception as e:  # pragma: no cover - MariaDB <10.3 lacks IF NOT EXISTS
+                log_warning(f"[chatlink] chat_name column add failed: {e}")
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS message_thread_name TEXT"
+                )
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] message_thread_name column add failed: {e}")
+            await conn.commit()
+        conn.close()
+        self._table_ensured = True
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    async def get_link(
+        self,
+        chat_id: int | str | None = None,
+        message_thread_id: Optional[int | str] = None,
+        *,
+        chat_name: Optional[str] = None,
+        message_thread_name: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return the ChatGPT link for the given identifiers."""
+
+        await self._ensure_table()
+        conn = await get_conn()
+        try:
+            async with conn.cursor(aiomysql.DictCursor) as cursor:
+                if chat_id is not None:
+                    normalized = self._normalize_thread_id(message_thread_id)
+                    chat_id_str = str(chat_id)
+                    log_debug(
+                        f"[chatlink] Searching for link: chat_id={chat_id_str}, message_thread_id={normalized}"
+                    )
+                    await cursor.execute(
+                        """
+                        SELECT link FROM chatgpt_links
+                        WHERE chat_id = %s AND message_thread_id = %s
+                        """,
+                        (chat_id_str, normalized),
+                    )
+                elif chat_name is not None:
+                    norm_name = self._normalize_name(message_thread_name)
+                    log_debug(
+                        f"[chatlink] Searching for link: chat_name={chat_name}, message_thread_name={norm_name}"
+                    )
+                    if norm_name is None:
+                        await cursor.execute(
+                            """
+                            SELECT link FROM chatgpt_links
+                            WHERE chat_name = %s AND message_thread_name IS NULL
+                            """,
+                            (chat_name,),
+                        )
+                    else:
+                        await cursor.execute(
+                            """
+                            SELECT link FROM chatgpt_links
+                            WHERE chat_name = %s AND message_thread_name = %s
+                            """,
+                            (chat_name, norm_name),
+                        )
+                else:
+                    return None
+                row = await cursor.fetchone()
+        finally:
+            conn.close()
+        if row:
+            return row.get("link")
+        return None
+
+    async def save_link(
+        self,
+        chat_id: int | str,
+        message_thread_id: Optional[int | str],
+        link: str,
+        *,
+        chat_name: Optional[str] = None,
+        message_thread_name: Optional[str] = None,
+    ) -> None:
+        """Persist a mapping between a chat (and optional thread) and a link."""
+
+        await self._ensure_table()
+        normalized = self._normalize_thread_id(message_thread_id)
+        chat_id_str = str(chat_id)
+        name = self._normalize_name(chat_name)
+        thread_name = self._normalize_name(message_thread_name)
+        conn = await get_conn()
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                INSERT INTO chatgpt_links
+                    (chat_id, message_thread_id, link, chat_name, message_thread_name)
+                VALUES (%s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE
+                    link=VALUES(link),
+                    chat_name=VALUES(chat_name),
+                    message_thread_name=VALUES(message_thread_name)
+                """,
+                (chat_id_str, normalized, link, name, thread_name),
+            )
+            await conn.commit()
+        conn.close()
+        log_debug(
+            f"[chatlink] Saved mapping {chat_id_str}/{normalized} -> {link}"
+        )
+
+    async def remove(
+        self,
+        chat_id: int | str | None = None,
+        message_thread_id: Optional[int | str] = None,
+        *,
+        chat_name: Optional[str] = None,
+        message_thread_name: Optional[str] = None,
+    ) -> bool:
+        """Remove a mapping. Returns True if a row was deleted."""
+
+        await self._ensure_table()
+        conn = await get_conn()
+        try:
+            async with conn.cursor() as cursor:
+                if chat_id is not None:
+                    normalized = self._normalize_thread_id(message_thread_id)
+                    chat_id_str = str(chat_id)
+                    result = await cursor.execute(
+                        """
+                        DELETE FROM chatgpt_links
+                        WHERE chat_id = %s AND message_thread_id = %s
+                        """,
+                        (chat_id_str, normalized),
+                    )
+                elif chat_name is not None:
+                    norm_name = self._normalize_name(message_thread_name)
+                    if norm_name is None:
+                        result = await cursor.execute(
+                            """
+                            DELETE FROM chatgpt_links
+                            WHERE chat_name = %s AND message_thread_name IS NULL
+                            """,
+                            (chat_name,),
+                        )
+                    else:
+                        result = await cursor.execute(
+                            """
+                            DELETE FROM chatgpt_links
+                            WHERE chat_name = %s AND message_thread_name = %s
+                            """,
+                            (chat_name, norm_name),
+                        )
+                else:
+                    return False
+                await conn.commit()
+        finally:
+            conn.close()
+        return result > 0
+
+    async def update_names(
+        self,
+        chat_id: int | str,
+        message_thread_id: Optional[int | str],
+        *,
+        chat_name: Optional[str] = None,
+        message_thread_name: Optional[str] = None,
+    ) -> bool:
+        """Update stored chat or thread names. Returns True if a row was updated."""
+
+        if chat_name is None and message_thread_name is None:
+            return False
+        await self._ensure_table()
+        normalized = self._normalize_thread_id(message_thread_id)
+        chat_id_str = str(chat_id)
+        fields = []
+        params: list[Any] = []
+        if chat_name is not None:
+            fields.append("chat_name = %s")
+            params.append(self._normalize_name(chat_name))
+        if message_thread_name is not None:
+            fields.append("message_thread_name = %s")
+            params.append(self._normalize_name(message_thread_name))
+        params.extend([chat_id_str, normalized])
+        query = f"UPDATE chatgpt_links SET {', '.join(fields)} WHERE chat_id = %s AND message_thread_id = %s"
+        conn = await get_conn()
+        try:
+            async with conn.cursor() as cursor:
+                result = await cursor.execute(query, params)
+                await conn.commit()
+        finally:
+            conn.close()
+        return result > 0
+
+    async def resolve_chat(
+        self, chat_name: str, message_thread_name: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve a chat by name returning identifiers and link."""
+
+        await self._ensure_table()
+        conn = await get_conn()
+        try:
+            async with conn.cursor(aiomysql.DictCursor) as cursor:
+                norm_name = self._normalize_name(message_thread_name)
+                if norm_name is None:
+                    await cursor.execute(
+                        """
+                        SELECT chat_id, message_thread_id, link
+                        FROM chatgpt_links
+                        WHERE chat_name = %s AND message_thread_name IS NULL
+                        """,
+                        (chat_name,),
+                    )
+                else:
+                    await cursor.execute(
+                        """
+                        SELECT chat_id, message_thread_id, link
+                        FROM chatgpt_links
+                        WHERE chat_name = %s AND message_thread_name = %s
+                        """,
+                        (chat_name, norm_name),
+                    )
+                row = await cursor.fetchone()
+        finally:
+            conn.close()
+        return row
+
+
+__all__ = ["ChatLinkStore"]
+

--- a/core/core_initializer.py
+++ b/core/core_initializer.py
@@ -9,9 +9,6 @@ from typing import Optional, Any
 from core.logging_utils import log_info, log_error, log_warning, log_debug
 from core.config import get_active_llm, list_available_llms
 
-# Ensure core actions (like chat_link) are registered
-import core.chat_link_actions  # noqa: F401
-
 
 class CoreInitializer:
     """Centralizes the initialization of all Rekku components."""
@@ -476,3 +473,6 @@ def register_interface(name: str, interface_obj: Any) -> None:
         flush_pending_for_interface(name)
     except Exception:
         pass
+
+# Ensure core actions (like chat_link) are registered after core setup
+import core.chat_link_actions  # noqa: F401

--- a/core/core_initializer.py
+++ b/core/core_initializer.py
@@ -9,6 +9,9 @@ from typing import Optional, Any
 from core.logging_utils import log_info, log_error, log_warning, log_debug
 from core.config import get_active_llm, list_available_llms
 
+# Ensure core actions (like chat_link) are registered
+import core.chat_link_actions  # noqa: F401
+
 
 class CoreInitializer:
     """Centralizes the initialization of all Rekku components."""

--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -131,7 +131,16 @@ async def handle_incoming_message(bot, message, context_memory_or_prompt):
         log_debug(
             f"[plugin] Incoming for {plugin.__class__.__name__}: chat_id={message.chat_id}, user_id={user_id}, text={message_text!r}"
         )
-        prompt = await build_json_prompt(message, context_memory_or_prompt)
+        if isinstance(context_memory_or_prompt, str):
+            try:
+                import json
+
+                prompt = json.loads(context_memory_or_prompt)
+            except Exception as e:
+                log_warning(f"[plugin_instance] Failed to parse direct prompt: {e}")
+                prompt = await build_json_prompt(message, {})
+        else:
+            prompt = await build_json_prompt(message, context_memory_or_prompt)
 
     prompt = sanitize_for_json(prompt)
     log_debug("🌐 JSON PROMPT built for the plugin:")

--- a/core/transport_layer.py
+++ b/core/transport_layer.py
@@ -42,8 +42,19 @@ def extract_json_from_text(text: str, processed_messages: set = None):
             return None
             
         # Don't parse JSON from error reports or correction requests
-        if any(keyword in text for keyword in ['"error_report"', '"correction_needed"', '🚨 ACTION PARSING ERRORS DETECTED 🚨', 'Please fix these actions']):
-            log_debug("[extract_json_from_text] Skipping error report/correction request - not actionable JSON")
+        if any(
+            keyword in text
+            for keyword in [
+                '"error_report"',
+                '"correction_needed"',
+                '🚨 ACTION PARSING ERRORS DETECTED 🚨',
+                'Please fix these actions',
+                '"system_message"',
+            ]
+        ):
+            log_debug(
+                "[extract_json_from_text] Skipping error report/correction request - not actionable JSON"
+            )
             return None
         
         # Handle the common ChatGPT pattern: "json\nCopy\nEdit\n{...}"

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -11,7 +11,6 @@ import threading
 import asyncio
 from collections import defaultdict
 from typing import Optional, Dict
-import aiomysql
 import subprocess
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
@@ -36,98 +35,7 @@ import core.recent_chats as recent_chats
 from core.ai_plugin_base import AIPluginBase
 
 # ChatLinkStore: gestisce la mappatura tra chat Telegram e chat ChatGPT
-from core.db import get_conn
-
-class ChatLinkStore:
-    def __init__(self):
-        self._table_ensured = False
-
-    def _normalize_thread_id(self, message_thread_id: Optional[int | str]) -> str:
-        """Return ``message_thread_id`` as a non-null string."""
-        return str(message_thread_id) if message_thread_id is not None else "0"
-
-    async def _ensure_table(self) -> None:
-        if self._table_ensured:
-            return
-        conn = await get_conn()
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS chatgpt_links (
-                    chat_id TEXT NOT NULL,
-                    message_thread_id TEXT,
-                    link VARCHAR(2048),
-                    PRIMARY KEY (chat_id(255), message_thread_id(255))
-                )
-                """
-            )
-            await conn.commit()
-        conn.close()
-        self._table_ensured = True
-
-    async def get_link(self, chat_id: int | str, message_thread_id: Optional[int | str]) -> Optional[str]:
-        await self._ensure_table()
-        normalized = self._normalize_thread_id(message_thread_id)
-        chat_id_str = str(chat_id)
-        log_debug(f"[chatlink] Searching for link: chat_id={chat_id_str}, message_thread_id={normalized}")
-        conn = await get_conn()
-        async with conn.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.execute(
-                """
-                SELECT link
-                FROM chatgpt_links
-                WHERE chat_id = %s AND message_thread_id = %s
-                """,
-                (chat_id_str, normalized),
-            )
-            row = await cursor.fetchone()
-        conn.close()
-        if row:
-            link_value = row.get("link")
-            log_debug(f"[chatlink] Found mapping {chat_id_str}/{normalized} -> {link_value}")
-            return link_value
-        log_debug(f"[chatlink] No row found for {chat_id_str}/{normalized}")
-        return None
-
-    async def save_link(self, chat_id: int | str, message_thread_id: Optional[int | str], link: str) -> None:
-        await self._ensure_table()
-        normalized = self._normalize_thread_id(message_thread_id)
-        chat_id_str = str(chat_id)
-        conn = await get_conn()
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                """
-                INSERT INTO chatgpt_links (chat_id, message_thread_id, link)
-                VALUES (%s, %s, %s)
-                ON DUPLICATE KEY UPDATE link=VALUES(link)
-                """,
-                (chat_id_str, normalized, link),
-            )
-            await conn.commit()
-        conn.close()
-        log_debug(f"[chatlink] Saved mapping {chat_id_str}/{normalized} -> {link}")
-
-    async def remove(self, chat_id: int | str, message_thread_id: Optional[int | str]) -> bool:
-        await self._ensure_table()
-        normalized = self._normalize_thread_id(message_thread_id)
-        chat_id_str = str(chat_id)
-        conn = await get_conn()
-        async with conn.cursor() as cursor:
-            result = await cursor.execute(
-                """
-                DELETE FROM chatgpt_links
-                WHERE chat_id = %s AND message_thread_id = %s
-                """,
-                (chat_id_str, normalized),
-            )
-            await conn.commit()
-        conn.close()
-        rows_deleted = cursor.rowcount > 0
-        if rows_deleted:
-            log_debug(f"[chatlink] Removed link for chat_id={chat_id_str}, message_thread_id={normalized}")
-        else:
-            log_debug(f"[chatlink] No link found for chat_id={chat_id_str}, message_thread_id={normalized}")
-        return rows_deleted
+from core.chat_link_store import ChatLinkStore
 from core.telegram_utils import safe_send
 
 # Fallback per notify_trainer se non disponibile

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -101,6 +101,12 @@ class TestCorrectorRetry(unittest.TestCase):
         self.assertIsNone(
             extract_json_from_text('{"system_message": {"type": "error", "message": "fail"}}')
         )
+        self.assertIsNone(
+            extract_json_from_text('{"system_message": {"type": "output", "message": "ok"}}')
+        )
+        self.assertIsNone(
+            extract_json_from_text('{"system_message": {"type": "event", "message": "ping"}}')
+        )
         
         # Valid JSON should parse
         valid_json = '{"type": "message", "payload": {"text": "Hello"}}'

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -94,10 +94,13 @@ class TestCorrectorRetry(unittest.TestCase):
         self.assertIsNone(extract_json_from_text("[WARNING] Some warning"))
         self.assertIsNone(extract_json_from_text("[INFO] Some info"))
         self.assertIsNone(extract_json_from_text("[DEBUG] Some debug"))
-        
+
         # Error reports should return None
         self.assertIsNone(extract_json_from_text('🚨 ACTION PARSING ERRORS DETECTED 🚨'))
         self.assertIsNone(extract_json_from_text('Please fix these actions'))
+        self.assertIsNone(
+            extract_json_from_text('{"system_message": {"type": "error", "message": "fail"}}')
+        )
         
         # Valid JSON should parse
         valid_json = '{"type": "message", "payload": {"text": "Hello"}}'


### PR DESCRIPTION
## Summary
- centralize chat link update_chat_name action within core
- remove standalone chat_link plugin
- auto-load core chat link actions during initialization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiomysql')*

------
https://chatgpt.com/codex/tasks/task_e_68a553656acc83288637b45a1310d027