### PR TITLE
feat: allow empty action response

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Tuple, Optional
 
 from core.logging_utils import log_debug, log_info, log_warning, log_error
-from core.prompt_engine import load_json_instructions
+from core.prompt_engine import build_full_json_instructions
 
 # Global dictionary to track retry attempts per chat/message thread for the corrector
 CORRECTOR_RETRIES = int(os.getenv("CORRECTOR_RETRIES", "2"))
@@ -93,10 +93,13 @@ async def corrector(errors: list, failed_actions: list, bot, message):
         "Please repeat your previous message, not this very prompt, but your previous reply, corrected. "
         "If that was a web search please use the content to reply with your own words."
     )
+    full_json = build_full_json_instructions()
     correction_payload = {
         "system_message": {
             "type": "error",
             "message": message_text,
+            "your_reply": getattr(message, "text", ""),
+            "full_json_instructions": full_json,
             "error_retry_policy": ERROR_RETRY_POLICY,
         }
     }

--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -22,8 +22,9 @@ _retry_tracker = {}
 ERROR_RETRY_POLICY = {
     "description": (
         "If you receive a system_message of type 'error' with the phrase 'Please repeat your "
-        "previous message, corrected.' you must automatically re-send the exact same JSON you sent "
-        "previously, but with the part indicated as invalid corrected."
+        "previous message, not this very prompt, but your previous reply, corrected.' you must "
+        "automatically re-send the exact same JSON you sent previously, but with the part "
+        "indicated as invalid corrected."
     ),
     "steps": [
         "1. Identify which part of your last sent JSON caused the error (e.g. an unsupported action type or missing parameter).",
@@ -89,7 +90,7 @@ async def corrector(errors: list, failed_actions: list, bot, message):
 
     message_text = (
         f"{error_summary}\n"
-        "Please repeat your previous message, corrected."
+        "Please repeat your previous message, not this very prompt, but your previous reply, corrected."
     )
     correction_payload = {
         "system_message": {

--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -22,9 +22,9 @@ _retry_tracker = {}
 ERROR_RETRY_POLICY = {
     "description": (
         "If you receive a system_message of type 'error' with the phrase 'Please repeat your "
-        "previous message, not this very prompt, but your previous reply, corrected.' you must "
-        "automatically re-send the exact same JSON you sent previously, but with the part "
-        "indicated as invalid corrected."
+        "previous message, not this very prompt, but your previous reply, corrected. If that was a "
+        "web search please use the content to reply with your own words.' you must automatically "
+        "re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected."
     ),
     "steps": [
         "1. Identify which part of your last sent JSON caused the error (e.g. an unsupported action type or missing parameter).",
@@ -90,7 +90,8 @@ async def corrector(errors: list, failed_actions: list, bot, message):
 
     message_text = (
         f"{error_summary}\n"
-        "Please repeat your previous message, not this very prompt, but your previous reply, corrected."
+        "Please repeat your previous message, not this very prompt, but your previous reply, corrected. "
+        "If that was a web search please use the content to reply with your own words."
     )
     correction_payload = {
         "system_message": {

--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -98,7 +98,7 @@ async def corrector(errors: list, failed_actions: list, bot, message):
         "system_message": {
             "type": "error",
             "message": message_text,
-            "your_reply": getattr(message, "text", ""),
+            "your_reply": getattr(message, "original_text", getattr(message, "text", "")),
             "full_json_instructions": full_json,
             "error_retry_policy": ERROR_RETRY_POLICY,
         }

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -9,6 +9,7 @@ import json
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from typing import Dict, Any, Optional
 from datetime import datetime
+from core.prompt_engine import build_full_json_instructions
 
 
 class AutoResponseSystem:
@@ -81,8 +82,13 @@ class AutoResponseSystem:
             mock_message.chat.first_name = "AutoResponse"
             mock_message.chat.type = "private"
             
+            full_json = build_full_json_instructions()
             system_payload = {
-                "system_message": {"type": "output", "message": output}
+                "system_message": {
+                    "type": "output",
+                    "message": output,
+                    "full_json_instructions": full_json,
+                }
             }
 
             log_info(
@@ -162,13 +168,22 @@ async def request_llm_delivery(
             # If we have a message, use it directly with plugin_instance
             import json
 
+            full_json = build_full_json_instructions()
             if isinstance(context, dict) and context.get("input", {}).get("type") == "event":
                 system_payload = {
-                    "system_message": {"type": "event", "message": context}
+                    "system_message": {
+                        "type": "event",
+                        "message": context,
+                        "full_json_instructions": full_json,
+                    }
                 }
             else:
                 system_payload = {
-                    "system_message": {"type": "output", "message": context}
+                    "system_message": {
+                        "type": "output",
+                        "message": context,
+                        "full_json_instructions": full_json,
+                    }
                 }
 
             payload_json = json.dumps(system_payload, ensure_ascii=False)

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -218,4 +218,16 @@ The JSON is just a wrapper — speak naturally as you always do.
 """
 
 
+def build_full_json_instructions() -> dict:
+    """Return combined JSON instructions and available actions block."""
+    instructions = load_json_instructions()
+    actions = {}
+    try:
+        from core.core_initializer import core_initializer
+        actions = core_initializer.actions_block.get("available_actions", {})
+    except Exception as e:  # pragma: no cover - defensive
+        log_warning(f"[prompt_engine] Failed to load actions block: {e}")
+    return {"instructions": instructions, "actions": actions}
+
+
 

--- a/core/transport_layer.py
+++ b/core/transport_layer.py
@@ -216,6 +216,7 @@ async def universal_send(interface_send_func, *args, text: str = None, **kwargs)
 
             message.chat_id = chat_id_value
             message.text = ""
+            message.original_text = text
             message.message_thread_id = kwargs.get('message_thread_id')
             from datetime import datetime
             message.date = datetime.utcnow()
@@ -260,6 +261,7 @@ async def universal_send(interface_send_func, *args, text: str = None, **kwargs)
         message = SimpleNamespace()
         message.chat_id = kwargs.get('chat_id') or (args[0] if args else None)
         message.text = text
+        message.original_text = text
         message.message_thread_id = kwargs.get('message_thread_id')
         from datetime import datetime
         message.date = datetime.utcnow()
@@ -347,6 +349,7 @@ async def telegram_safe_send(bot, chat_id: int, text: str, chunk_size: int = 400
             message = SimpleNamespace()
             message.chat_id = chat_id
             message.text = ""
+            message.original_text = text
             message.message_thread_id = kwargs.get('message_thread_id')
             if 'event_id' in kwargs:
                 message.event_id = kwargs['event_id']
@@ -379,6 +382,7 @@ async def telegram_safe_send(bot, chat_id: int, text: str, chunk_size: int = 400
         message = SimpleNamespace()
         message.chat_id = chat_id
         message.text = text
+        message.original_text = text
         message.message_thread_id = kwargs.get('message_thread_id')
         if 'event_id' in kwargs:
             message.event_id = kwargs['event_id']

--- a/docs/auto_response.rst
+++ b/docs/auto_response.rst
@@ -133,6 +133,9 @@ Error system messages include an ``error_retry_policy`` instructing the
 LLM how to resubmit corrected JSON. The policy describes the steps to
 repeat the previous request while adjusting only the invalid portion.
 
+All system messages also contain a ``full_json_instructions`` block that
+reminds the LLM of the JSON format and available actions.
+
 These system messages are ignored during JSON extraction, preventing
 unintended actions.
 

--- a/docs/chat_links.rst
+++ b/docs/chat_links.rst
@@ -34,16 +34,16 @@ structured system message:
            "type": "error",
            "message": "Multiple channels found with name <name>; please retry with the numeric chat_id",
            "error_retry_policy": {
-               "description": "If you receive a system_message of type 'error' with the phrase 'Please repeat your previous message, corrected.' you must automatically re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected.",
-               "steps": [
-                   "1. Identify which part of your last sent JSON caused the error (e.g. an unsupported action type or missing parameter).",
-                   "2. Create a new JSON that is identical to the one you previously sent, except for correcting ONLY the invalid part.",
-                   "3. Do not add, remove or reorder any other actions or payload content.",
-                   "4. Re-submit the corrected JSON immediately (without waiting for user instructions)."
-               ]
-           }
-       }
-   }
+              "description": "If you receive a system_message of type 'error' with the phrase 'Please repeat your previous message, not this very prompt, but your previous reply, corrected.' you must automatically re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected.",
+              "steps": [
+                  "1. Identify which part of your last sent JSON caused the error (e.g. an unsupported action type or missing parameter).",
+                  "2. Create a new JSON that is identical to the one you previously sent, except for correcting ONLY the invalid part.",
+                  "3. Do not add, remove or reorder any other actions or payload content.",
+                  "4. Re-submit the corrected JSON immediately (without waiting for user instructions)."
+              ]
+          }
+      }
+  }
 
 The LLM should resend the original action using explicit IDs.
 

--- a/docs/chat_links.rst
+++ b/docs/chat_links.rst
@@ -33,6 +33,8 @@ structured system message:
        "system_message": {
            "type": "error",
            "message": "Multiple channels found with name <name>; please retry with the numeric chat_id",
+           "your_reply": "<original reply>",
+           "full_json_instructions": {"instructions": "...", "actions": { ... }},
            "error_retry_policy": {
              "description": "If you receive a system_message of type 'error' with the phrase 'Please repeat your previous message, not this very prompt, but your previous reply, corrected. If that was a web search please use the content to reply with your own words.' you must automatically re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected.",
               "steps": [

--- a/docs/chat_links.rst
+++ b/docs/chat_links.rst
@@ -34,7 +34,7 @@ structured system message:
            "type": "error",
            "message": "Multiple channels found with name <name>; please retry with the numeric chat_id",
            "error_retry_policy": {
-              "description": "If you receive a system_message of type 'error' with the phrase 'Please repeat your previous message, not this very prompt, but your previous reply, corrected.' you must automatically re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected.",
+             "description": "If you receive a system_message of type 'error' with the phrase 'Please repeat your previous message, not this very prompt, but your previous reply, corrected. If that was a web search please use the content to reply with your own words.' you must automatically re-send the exact same JSON you sent previously, but with the part indicated as invalid corrected.",
               "steps": [
                   "1. Identify which part of your last sent JSON caused the error (e.g. an unsupported action type or missing parameter).",
                   "2. Create a new JSON that is identical to the one you previously sent, except for correcting ONLY the invalid part.",

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -1175,7 +1175,7 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                     queue_paused = False
 
                 if not response_text:
-                    response_text = "\u26a0\ufe0f No response received"
+                    response_text = json.dumps({"actions": []})
 
                 await safe_send(
                     bot,

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -99,18 +99,19 @@ class TestCorrectorRetry(unittest.TestCase):
         self.assertIsNone(extract_json_from_text('🚨 ACTION PARSING ERRORS DETECTED 🚨'))
         self.assertIsNone(extract_json_from_text('Please fix these actions'))
         self.assertIsNone(
-            extract_json_from_text('{"system_message": {"type": "error", "message": "fail"}}')
-        )
-        self.assertIsNone(
             extract_json_from_text(
-                '{"system_message": {"type": "error", "message": "fail", "error_retry_policy": {"description": "d", "steps": ["1"]}}}'
+                '{"system_message": {"type": "error", "message": "fail", "your_reply": "orig", "full_json_instructions": {}, "error_retry_policy": {"description": "d", "steps": ["1"]}}}'
             )
         )
         self.assertIsNone(
-            extract_json_from_text('{"system_message": {"type": "output", "message": "ok"}}')
+            extract_json_from_text(
+                '{"system_message": {"type": "output", "message": "ok", "full_json_instructions": {}}}'
+            )
         )
         self.assertIsNone(
-            extract_json_from_text('{"system_message": {"type": "event", "message": "ping"}}')
+            extract_json_from_text(
+                '{"system_message": {"type": "event", "message": "ping", "full_json_instructions": {}}}'
+            )
         )
         
         # Valid JSON should parse


### PR DESCRIPTION
## Summary
- avoid sending a warning when ChatGPT returns no text by defaulting to empty actions
- trigger the corrector when the LLM sends non-JSON output to prevent plain messages from reaching interfaces

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'aiomysql')*

------
https://chatgpt.com/codex/tasks/task_e_68a6671c21748328a537bc59dfab621d