### PR TITLE
Handle 1:1 chats and centralize message filtering

### DIFF
--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -40,14 +40,18 @@ async def _delayed_put(item: dict, delay: float) -> None:
 
 async def enqueue(bot, message, context_memory, priority: bool = False) -> None:
     """Enqueue a message for serialized processing with rate limiting.
-    
+
     Args:
         bot: The bot instance
         message: The message to process
         context_memory: Message context
         priority: If True, message is added to front of queue (for events)
     """
-    if not await is_message_for_bot(message, bot):
+    human_count = getattr(message, "human_count", None)
+    if human_count is None and hasattr(message, "chat"):
+        human_count = getattr(message.chat, "human_count", None)
+
+    if not await is_message_for_bot(message, bot, human_count=human_count):
         log_debug("[QUEUE] Message ignored: not directed to bot")
         return
 

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from core.config import TELEGRAM_TRAINER_ID
 from core import plugin_instance, rate_limit, recent_chats
 from core.logging_utils import log_debug, log_error, log_warning, log_info
+from core.mention_utils import is_message_for_bot
 
 # Use a priority queue so events can be processed before regular messages
 HIGH_PRIORITY = 0
@@ -46,6 +47,10 @@ async def enqueue(bot, message, context_memory, priority: bool = False) -> None:
         context_memory: Message context
         priority: If True, message is added to front of queue (for events)
     """
+    if not await is_message_for_bot(message, bot):
+        log_debug("[QUEUE] Message ignored: not directed to bot")
+        return
+
     plugin = plugin_instance.get_plugin()
     if not plugin:
         log_error("[QUEUE] No active plugin")

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -51,8 +51,20 @@ async def enqueue(bot, message, context_memory, priority: bool = False) -> None:
     if human_count is None and hasattr(message, "chat"):
         human_count = getattr(message.chat, "human_count", None)
 
-    if not await is_message_for_bot(message, bot, human_count=human_count):
-        log_debug("[QUEUE] Message ignored: not directed to bot")
+    directed, reason = await is_message_for_bot(
+        message, bot, human_count=human_count
+    )
+    if not directed:
+        if reason == "missing_human_count":
+            log_debug(
+                "[QUEUE] Message ignored: interface lacks participant count and no direct mention"
+            )
+        elif reason == "multiple_humans":
+            log_debug(
+                "[QUEUE] Message ignored: multiple humans in chat and no direct mention"
+            )
+        else:
+            log_debug(f"[QUEUE] Message ignored: {reason or 'not directed to bot'}")
         return
 
     plugin = plugin_instance.get_plugin()

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -36,8 +36,6 @@ from core.message_sender import (
 )
 from core.config import get_active_llm, set_active_llm, list_available_llms
 from core.config import BOT_TOKEN, BOT_USERNAME, TELEGRAM_TRAINER_ID
-# Import mention detector to recognize Rekku aliases even without explicit @username
-from core.mention_utils import is_rekku_mentioned, is_message_for_bot
 
 from core.chat_link_store import (
     ChatLinkStore,
@@ -343,22 +341,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         else:
             log_warning("⚠️ No target found for reply. Ensure plugin mapping is correct.")
             await message.reply_text("⚠️ No message found to reply to.")
-        return
-
-    # === FILTER: Only respond if mentioned or in reply
-    log_debug(f"[telegram_bot] Checking if message is for bot: chat_type={message.chat.type}, "
-              f"text='{text[:50]}{'...' if len(text) > 50 else ''}', "
-              f"reply_message_id={message.reply_to_message is not None}")
-    
-    if message.reply_to_message:
-        log_debug(f"[telegram_bot] Reply to message from user ID: {message.reply_to_message.from_user.id if message.reply_to_message.from_user else 'None'}, "
-                  f"username: {message.reply_to_message.from_user.username if message.reply_to_message.from_user else 'None'}")
-    
-    is_for_bot = await is_message_for_bot(message, context.bot)
-    log_debug(f"[telegram_bot] is_message_for_bot result: {is_for_bot}")
-    
-    if not is_for_bot:
-        log_debug("Ignoring message: no Rekku mention detected.")
         return
 
     # === Forward to centralized queue

--- a/tests/test_mention_utils.py
+++ b/tests/test_mention_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from types import SimpleNamespace
+import sys, os
+
+# Add parent directory to path so that 'core' can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core import mention_utils
+
+class DummyBot:
+    def __init__(self):
+        self._me = SimpleNamespace(id=999, username="RekkuBot")
+    async def get_me(self):
+        return self._me
+
+def test_one_to_one_group_chat_detection():
+    mention_utils._GROUP_CHAT_HUMANS.clear()
+    bot = DummyBot()
+    chat = SimpleNamespace(id=-100, type="group", title="Test")
+
+    async def run_test():
+        user1 = SimpleNamespace(id=1, is_bot=False, username="alice")
+        message1 = SimpleNamespace(chat=chat, from_user=user1, text="ciao", caption=None, entities=None, reply_to_message=None)
+        assert await mention_utils.is_message_for_bot(message1, bot)
+
+        user2 = SimpleNamespace(id=2, is_bot=False, username="bob")
+        message2 = SimpleNamespace(chat=chat, from_user=user2, text="hello", caption=None, entities=None, reply_to_message=None)
+        assert not await mention_utils.is_message_for_bot(message2, bot)
+
+        message3 = SimpleNamespace(chat=chat, from_user=user1, text="again", caption=None, entities=None, reply_to_message=None)
+        assert not await mention_utils.is_message_for_bot(message3, bot)
+
+    import asyncio
+    asyncio.run(run_test())

--- a/tests/test_mention_utils.py
+++ b/tests/test_mention_utils.py
@@ -29,8 +29,15 @@ def test_one_to_one_detection_with_explicit_count():
     )
 
     async def run():
-        assert await mention_utils.is_message_for_bot(message, bot, human_count=1)
-        assert not await mention_utils.is_message_for_bot(message, bot, human_count=3)
+        directed, reason = await mention_utils.is_message_for_bot(
+            message, bot, human_count=1
+        )
+        assert directed and reason is None
+
+        directed, reason = await mention_utils.is_message_for_bot(
+            message, bot, human_count=3
+        )
+        assert not directed and reason == "multiple_humans"
 
     asyncio.run(run())
 
@@ -49,7 +56,8 @@ def test_no_auto_detection_when_count_unknown():
     )
 
     async def run():
-        assert not await mention_utils.is_message_for_bot(message, bot)
+        directed, reason = await mention_utils.is_message_for_bot(message, bot)
+        assert not directed and reason == "missing_human_count"
 
     asyncio.run(run())
 

--- a/tests/test_mention_utils.py
+++ b/tests/test_mention_utils.py
@@ -1,34 +1,55 @@
-import pytest
 from types import SimpleNamespace
-import sys, os
+import sys, os, asyncio
 
 # Add parent directory to path so that 'core' can be imported
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core import mention_utils
 
+
 class DummyBot:
     def __init__(self):
         self._me = SimpleNamespace(id=999, username="RekkuBot")
+
     async def get_me(self):
         return self._me
 
-def test_one_to_one_group_chat_detection():
-    mention_utils._GROUP_CHAT_HUMANS.clear()
+
+def test_one_to_one_detection_with_explicit_count():
     bot = DummyBot()
     chat = SimpleNamespace(id=-100, type="group", title="Test")
+    user = SimpleNamespace(id=1, is_bot=False, username="alice")
+    message = SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text="ciao",
+        caption=None,
+        entities=None,
+        reply_to_message=None,
+    )
 
-    async def run_test():
-        user1 = SimpleNamespace(id=1, is_bot=False, username="alice")
-        message1 = SimpleNamespace(chat=chat, from_user=user1, text="ciao", caption=None, entities=None, reply_to_message=None)
-        assert await mention_utils.is_message_for_bot(message1, bot)
+    async def run():
+        assert await mention_utils.is_message_for_bot(message, bot, human_count=1)
+        assert not await mention_utils.is_message_for_bot(message, bot, human_count=3)
 
-        user2 = SimpleNamespace(id=2, is_bot=False, username="bob")
-        message2 = SimpleNamespace(chat=chat, from_user=user2, text="hello", caption=None, entities=None, reply_to_message=None)
-        assert not await mention_utils.is_message_for_bot(message2, bot)
+    asyncio.run(run())
 
-        message3 = SimpleNamespace(chat=chat, from_user=user1, text="again", caption=None, entities=None, reply_to_message=None)
-        assert not await mention_utils.is_message_for_bot(message3, bot)
 
-    import asyncio
-    asyncio.run(run_test())
+def test_no_auto_detection_when_count_unknown():
+    bot = DummyBot()
+    chat = SimpleNamespace(id=-100, type="group", title="Test")
+    user = SimpleNamespace(id=1, is_bot=False, username="alice")
+    message = SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text="hello",
+        caption=None,
+        entities=None,
+        reply_to_message=None,
+    )
+
+    async def run():
+        assert not await mention_utils.is_message_for_bot(message, bot)
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- Auto-detect 1:1 group chats and treat messages as directed to the bot.
- Move mention filtering into the core queue and simplify the Telegram interface.
- Add regression test for 1:1 chat detection.

## Testing
- `pytest` *(fails: No module named 'aiomysql')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies python-telegram-bot)*
- `pytest tests/test_mention_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6a3ff476483289bd5ab3ab9debf97