### PR TITLE
Fix log path and cleanup script reference

### DIFF
--- a/core/logging_utils.py
+++ b/core/logging_utils.py
@@ -8,9 +8,12 @@ from typing import Optional
 
 _logger: Optional[logging.Logger] = None
 
-# Default to a "logs" directory inside the repository rather than /config
-# so running the tests does not attempt to write to restricted locations.
-_DEFAULT_LOG_DIR = os.path.join(os.getcwd(), "logs")
+# Default to a "logs" directory rooted at the project so the working
+# directory does not influence where logs are written. This avoids attempts to
+# create `/logs` (which may not be writable) when the application is launched
+# from an arbitrary path.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_LOG_DIR = os.path.join(_REPO_ROOT, "logs")
 _LOG_DIR = os.getenv("LOG_DIR", _DEFAULT_LOG_DIR)
 _LOG_FILE = os.path.join(_LOG_DIR, "rekku.log")
 _LEVELS = {

--- a/s6-services/rekku/run
+++ b/s6-services/rekku/run
@@ -2,7 +2,7 @@
 set -e
 
 echo "[S6 Rekku] Pulizia processi precedenti..."
-/usr/local/bin/cleanup_chromium.sh || true
+/usr/local/bin/cleanup_chrome.sh || true
 
 echo "[S6 Rekku] Attendo /tmp/.X11-unix/X1..."
 while [ ! -e /tmp/.X11-unix/X1 ]; do


### PR DESCRIPTION
## Summary
- ensure log directory resolves to project root so log file is created
- correct S6 service script to invoke existing cleanup_chrome.sh

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe6030a4832896e67c4f4099e8d1