### PR TITLE
Centralize LLM delivery retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ NOTIFY_ERRORS_TO_INTERFACES=telegram_bot:1234567    # Comma-separated interface:
 REKKU_SELENIUM_HEADLESS=1                           # Set to 1 for headless mode, 0 for non-headless
 PROMPT_LOCATION="Kyoto,Japan"                       # Default location for prompts and plugins
 TZ=UTC                                              # Timezone for scheduled events
+WEATHER_FETCH_TIME=30                               # Minutes between weather fetches
 LOGGING_LEVEL=error                                 # Log level: debug, info, warn, error
 RESTRICT_ACTIONS=trainer_only                       # Restricts sensitive actions: on (deny all, default), trainer_only, off
 IMAGE_VERSION=latest-develop                        # Version of the Docker image, update as needed

--- a/automation_tools/s6-rc.d/websockify/run
+++ b/automation_tools/s6-rc.d/websockify/run
@@ -1,3 +1,4 @@
 #!/usr/bin/with-contenv sh
 mkdir -p /app/logs
-exec websockify --web=/usr/share/novnc 0.0.0.0:6901 localhost:5901 >> /app/logs/selkies.log 2>&1
+# Use selkies to proxy VNC over websockets and capture its output
+exec selkies --addr="localhost" --mode="websockets" >> /app/logs/selkies.log 2>&1

--- a/automation_tools/s6-rc.d/websockify/run
+++ b/automation_tools/s6-rc.d/websockify/run
@@ -1,2 +1,3 @@
 #!/usr/bin/with-contenv sh
-exec websockify --web=/usr/share/novnc 0.0.0.0:6901 localhost:5901
+mkdir -p /app/logs
+exec websockify --web=/usr/share/novnc 0.0.0.0:6901 localhost:5901 >> /app/logs/seklies.log 2>&1

--- a/automation_tools/s6-rc.d/websockify/run
+++ b/automation_tools/s6-rc.d/websockify/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 mkdir -p /app/logs
-exec websockify --web=/usr/share/novnc 0.0.0.0:6901 localhost:5901 >> /app/logs/seklies.log 2>&1
+exec websockify --web=/usr/share/novnc 0.0.0.0:6901 localhost:5901 >> /app/logs/selkies.log 2>&1

--- a/automation_tools/s6-rc.d/x11vnc/run
+++ b/automation_tools/s6-rc.d/x11vnc/run
@@ -1,2 +1,3 @@
 #!/usr/bin/with-contenv bash
-exec x11vnc -display :1 -rfbport 5901 -passwd rekku -shared -noshm -noxdamage
+mkdir -p /app/logs
+exec x11vnc -display :1 -rfbport 5901 -passwd rekku -shared -noshm -noxdamage >> /app/logs/vnc.log 2>&1

--- a/core/config.py
+++ b/core/config.py
@@ -44,7 +44,19 @@ NOTIFY_ERRORS_TO_INTERFACES = _parse_notify_interfaces(
     os.getenv("NOTIFY_ERRORS_TO_INTERFACES", "")
 )
 
+# Resolve the Telegram trainer ID from the mapping if the legacy
+# environment variable is missing or set to 0. This keeps backward
+# compatibility while allowing NOTIFY_ERRORS_TO_INTERFACES to be the
+# single source of truth for trainer IDs.
 TELEGRAM_TRAINER_ID = int(os.getenv("TELEGRAM_TRAINER_ID", "0") or 0)
+if TELEGRAM_TRAINER_ID == 0:
+    TELEGRAM_TRAINER_ID = NOTIFY_ERRORS_TO_INTERFACES.get("telegram_bot", 0)
+    if TELEGRAM_TRAINER_ID:
+        log_info(f"[config] TELEGRAM_TRAINER_ID resolved from NOTIFY_ERRORS_TO_INTERFACES: {TELEGRAM_TRAINER_ID}")
+    else:
+        log_warning("[config] TELEGRAM_TRAINER_ID not configured; trainer-only commands will be rejected")
+else:
+    log_info(f"[config] TELEGRAM_TRAINER_ID loaded from environment: {TELEGRAM_TRAINER_ID}")
 
 
 def get_trainer_id(interface_name: str) -> int | None:

--- a/core/config.py
+++ b/core/config.py
@@ -46,6 +46,21 @@ NOTIFY_ERRORS_TO_INTERFACES = _parse_notify_interfaces(
 
 TELEGRAM_TRAINER_ID = int(os.getenv("TELEGRAM_TRAINER_ID", "0") or 0)
 
+
+def get_trainer_id(interface_name: str) -> int | None:
+    """Return the trainer ID for the given interface.
+
+    Prefers the mapping provided by ``NOTIFY_ERRORS_TO_INTERFACES`` and
+    falls back to legacy environment variables (e.g. ``TELEGRAM_TRAINER_ID``)
+    when necessary.
+    """
+    trainer_id = NOTIFY_ERRORS_TO_INTERFACES.get(interface_name)
+    if trainer_id:
+        return trainer_id
+    if interface_name == "telegram_bot" and TELEGRAM_TRAINER_ID:
+        return TELEGRAM_TRAINER_ID
+    return None
+
 BOT_TOKEN = os.getenv("BOTFATHER_TOKEN") or os.getenv("TELEGRAM_TOKEN")
 BOT_USERNAME = "rekku_freedom_project"
 LLM_MODE = os.getenv("LLM_MODE", "manual")

--- a/core/db.py
+++ b/core/db.py
@@ -416,7 +416,13 @@ async def get_due_events(now: datetime | None = None) -> list[dict]:
             else:
                 event_dt = datetime.fromisoformat(str(scheduled_val).replace('Z', '+00:00'))
             if event_dt.tzinfo is None:
-                event_dt = event_dt.replace(tzinfo=timezone.utc)
+                from core.rekku_utils import get_local_timezone
+                event_dt = (
+                    event_dt.replace(tzinfo=get_local_timezone())
+                    .astimezone(timezone.utc)
+                )
+            else:
+                event_dt = event_dt.astimezone(timezone.utc)
         except Exception as e:
             log_warning(f"[get_due_events] Invalid datetime in next_run: {scheduled_val} - {e}")
             continue
@@ -465,7 +471,13 @@ async def mark_event_delivered(event_id: int) -> bool:
                 else:
                     next_run_dt = None
                 if next_run_dt and next_run_dt.tzinfo is None:
-                    next_run_dt = next_run_dt.replace(tzinfo=timezone.utc)
+                    from core.rekku_utils import get_local_timezone
+                    next_run_dt = (
+                        next_run_dt.replace(tzinfo=get_local_timezone())
+                        .astimezone(timezone.utc)
+                    )
+                elif next_run_dt:
+                    next_run_dt = next_run_dt.astimezone(timezone.utc)
             except Exception as e:
                 log_warning(f"[db] Invalid next_run for event {event_id}: {next_run_val} - {e}")
                 next_run_dt = None

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -109,8 +109,8 @@ def _send_text_to_textarea(driver, textarea, text: str) -> None:
 
     actual = driver.execute_script(f"return arguments[0].{prop};", textarea) or ""
     log_debug(f"[DEBUG] Length actually present in textarea: {len(actual)}")
-    # Only warn if the textarea is significantly shorter than the injected text
-    if len(clean_text) - len(actual) > 5:
+    # Only warn if the textarea differs noticeably from the injected text
+    if abs(len(clean_text) - len(actual)) > 5:
         log_warning(
             f"[selenium] textarea mismatch: expected {len(clean_text)} chars, found {len(actual)}"
         )
@@ -683,7 +683,7 @@ def process_prompt_in_chat(
             ) or ""
             expected_len = len(strip_non_bmp(prompt_text))
             # Allow small discrepancies (e.g., trailing spaces trimmed by ChatGPT)
-            if expected_len - len(final_value) > 5:
+            if abs(expected_len - len(final_value)) > 5:
                 log_warning(
                     f"[selenium] Prompt mismatch after paste: expected {expected_len} chars, got {len(final_value)}"
                 )

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -109,7 +109,7 @@ def _send_text_to_textarea(driver, textarea, text: str) -> None:
 
     actual = driver.execute_script(f"return arguments[0].{prop};", textarea) or ""
     log_debug(f"[DEBUG] Length actually present in textarea: {len(actual)}")
-    if actual != clean_text:
+    if len(actual) != len(clean_text):
         log_warning(
             f"[selenium] textarea mismatch: expected {len(clean_text)} chars, found {len(actual)}"
         )
@@ -260,6 +260,7 @@ def wait_for_markdown_block_to_appear(driver, prev_count: int, timeout: int = 10
 
 
 AWAIT_RESPONSE_TIMEOUT = int(os.getenv("AWAIT_RESPONSE_TIMEOUT", "240"))
+CORRECTOR_RETRIES = int(os.getenv("CORRECTOR_RETRIES", "2"))
 
 
 def wait_until_response_stabilizes(
@@ -669,7 +670,7 @@ def process_prompt_in_chat(
     attempt = 0
     repeat_failures = 0
     last_response: Optional[str] = None
-    while time.time() - start < AWAIT_RESPONSE_TIMEOUT:
+    while attempt < CORRECTOR_RETRIES and time.time() - start < AWAIT_RESPONSE_TIMEOUT:
         attempt += 1
         try:
             wait_for_chatgpt_idle(driver)
@@ -679,9 +680,10 @@ def process_prompt_in_chat(
             final_value = driver.execute_script(
                 f"return arguments[0].{prop};", textarea
             ) or ""
-            if final_value != strip_non_bmp(prompt_text):
+            expected_len = len(strip_non_bmp(prompt_text))
+            if len(final_value) != expected_len:
                 log_warning(
-                    f"[selenium] Prompt mismatch after paste: expected {len(prompt_text)} chars, got {len(final_value)}"
+                    f"[selenium] Prompt mismatch after paste: expected {expected_len} chars, got {len(final_value)}"
                 )
                 time.sleep(1)
                 continue
@@ -746,6 +748,7 @@ def process_prompt_in_chat(
         if remaining > 0:
             time.sleep(min(5, remaining))
 
+    log_warning(f"[selenium] Aborting after {attempt} attempts")
     screenshots_dir = os.path.join(_LOG_DIR, "screenshots")
     os.makedirs(screenshots_dir, exist_ok=True)
     fname = os.path.join(screenshots_dir, f"chat_{chat_id or 'unknown'}_no_response.png")

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -109,7 +109,8 @@ def _send_text_to_textarea(driver, textarea, text: str) -> None:
 
     actual = driver.execute_script(f"return arguments[0].{prop};", textarea) or ""
     log_debug(f"[DEBUG] Length actually present in textarea: {len(actual)}")
-    if len(actual) < len(clean_text):
+    # Only warn if the textarea is significantly shorter than the injected text
+    if len(actual) + 5 < len(clean_text):
         log_warning(
             f"[selenium] textarea mismatch: expected {len(clean_text)} chars, found {len(actual)}"
         )
@@ -681,7 +682,8 @@ def process_prompt_in_chat(
                 f"return arguments[0].{prop};", textarea
             ) or ""
             expected_len = len(strip_non_bmp(prompt_text))
-            if len(final_value) < expected_len:
+            # Allow small discrepancies (e.g., trailing spaces trimmed by ChatGPT)
+            if len(final_value) + 5 < expected_len:
                 log_warning(
                     f"[selenium] Prompt mismatch after paste: expected {expected_len} chars, got {len(final_value)}"
                 )

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -110,7 +110,7 @@ def _send_text_to_textarea(driver, textarea, text: str) -> None:
     actual = driver.execute_script(f"return arguments[0].{prop};", textarea) or ""
     log_debug(f"[DEBUG] Length actually present in textarea: {len(actual)}")
     # Only warn if the textarea is significantly shorter than the injected text
-    if len(actual) + 5 < len(clean_text):
+    if len(clean_text) - len(actual) > 5:
         log_warning(
             f"[selenium] textarea mismatch: expected {len(clean_text)} chars, found {len(actual)}"
         )
@@ -683,7 +683,7 @@ def process_prompt_in_chat(
             ) or ""
             expected_len = len(strip_non_bmp(prompt_text))
             # Allow small discrepancies (e.g., trailing spaces trimmed by ChatGPT)
-            if len(final_value) + 5 < expected_len:
+            if expected_len - len(final_value) > 5:
                 log_warning(
                     f"[selenium] Prompt mismatch after paste: expected {expected_len} chars, got {len(final_value)}"
                 )

--- a/plugins/event_plugin.py
+++ b/plugins/event_plugin.py
@@ -437,7 +437,7 @@ class EventPlugin(AIPluginBase):
                         break
 
                 if attempt < CORRECTOR_RETRIES and not delivered:
-                    await asyncio.sleep(1)
+                    await asyncio.sleep(attempt)
 
             if not delivered:
                 log_warning(

--- a/plugins/weather_plugin.py
+++ b/plugins/weather_plugin.py
@@ -21,9 +21,9 @@ class WeatherPlugin:
         self._cached_weather: Optional[str] = None
         self._last_fetch: float = 0.0
         try:
-            self.cache_minutes = int(os.getenv("WEATHER_CACHE_MINUTES", "30"))
+            self.fetch_minutes = int(os.getenv("WEATHER_FETCH_TIME", "30"))
         except ValueError:
-            self.cache_minutes = 30
+            self.fetch_minutes = 30
 
     # Plugin action registration
     def get_supported_action_types(self):
@@ -46,7 +46,7 @@ class WeatherPlugin:
         now = time.time()
         if (
             not self._cached_weather
-            or now - self._last_fetch > self.cache_minutes * 60
+            or now - self._last_fetch > self.fetch_minutes * 60
         ):
             await self._update_weather()
 

--- a/plugins/weather_plugin.py
+++ b/plugins/weather_plugin.py
@@ -58,7 +58,13 @@ class WeatherPlugin:
         try:
             response = await asyncio.to_thread(urllib.request.urlopen, url)
             data_bytes = await asyncio.to_thread(response.read)
-            data = json.loads(data_bytes.decode())
+            if not data_bytes:
+                raise ValueError("empty response")
+            try:
+                data = json.loads(data_bytes.decode())
+            except json.JSONDecodeError as e:
+                log_warning(f"[weather_plugin] Invalid JSON weather data: {e}")
+                return
             cc = data.get("current_condition", [{}])[0]
             desc = cc.get("weatherDesc", [{}])[0].get("value", "N/A")
             temp_c = cc.get("temp_C", "N/A")


### PR DESCRIPTION
## Summary
- centralize CORRECTOR_RETRIES-based retries in `request_llm_delivery`
- use centralized delivery in event plugin and mark events delivered even if retries fail

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fa5fff88328b295f9c2d4f41622