### PR TITLE
Use Chromium binary for Selenium components

### DIFF
--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -1120,6 +1120,16 @@ class SeleniumChatGPTPlugin(AIPluginBase):
         except Exception as e:
             log_warning(f"[selenium] Failed to set driver timeouts: {e}")
 
+    def _locate_chromium_binary(self) -> str:
+        """Return path to the Chromium executable, checking common locations."""
+        chromium_binary = (
+            shutil.which("chromium")
+            or shutil.which("chromium-browser")
+            or "/usr/bin/chromium"
+        )
+        log_debug(f"[selenium] Using Chromium binary: {chromium_binary}")
+        return chromium_binary
+
     def _init_driver(self):
         if self.driver is None:
             log_debug("[selenium] [STEP] Initializing Chromium driver with undetected-chromedriver")
@@ -1195,7 +1205,7 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                         log_debug("[selenium] Cleared undetected-chromedriver cache")
                     
                     # Try with explicit Chromium binary
-                    chromium_binary = shutil.which("chromium") or "/usr/bin/chromium"
+                    chromium_binary = self._locate_chromium_binary()
                     self.driver = uc.Chrome(
                         options=options,
                         headless=False,
@@ -1239,7 +1249,7 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                         # Final attempt with explicit Chromium binary
                         log_debug("[selenium] Final attempt with explicit Chromium binary path...")
                         try:
-                            chromium_binary = shutil.which("chromium") or "/usr/bin/chromium"
+                            chromium_binary = self._locate_chromium_binary()
                             if os.path.exists(chromium_binary):
                                 # Create fresh ChromiumOptions for fallback attempt
                                 fallback_options = uc.ChromeOptions()

--- a/plugins/selenium_elevenlabs.py
+++ b/plugins/selenium_elevenlabs.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import tempfile
 import time
+import shutil
 from typing import Any, Dict, List, Tuple
 
 import undetected_chromedriver as uc
@@ -120,7 +121,19 @@ class SeleniumElevenLabsPlugin:
                 "safebrowsing.enabled": True,
             }
             options.add_experimental_option("prefs", prefs)
-            driver = uc.Chrome(options=options)
+
+            chromium_binary = (
+                shutil.which("chromium")
+                or shutil.which("chromium-browser")
+                or "/usr/bin/chromium"
+            )
+            log_debug(f"[selenium_elevenlabs] Using Chromium binary: {chromium_binary}")
+            driver = uc.Chrome(
+                options=options,
+                headless=False,
+                use_subprocess=False,
+                browser_executable_path=chromium_binary,
+            )
             wait = WebDriverWait(driver, 60)
             try:
                 driver.get("https://elevenlabs.io/app/speech-synthesis/text-to-speech")


### PR DESCRIPTION
## Summary
- ensure ElevenLabs Selenium plugin explicitly uses Chromium binary
- update Selenium ChatGPT engine to detect and use Chromium instead of Chrome

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68b3de0cb4f48328af0f7ab16158035b