### PR TITLE
feat: centralize slash command handling

### DIFF
--- a/core/command_registry.py
+++ b/core/command_registry.py
@@ -1,0 +1,77 @@
+"""Backend registry for slash commands usable by any interface."""
+
+from typing import Awaitable, Callable, Dict, Any
+from core.logging_utils import log_debug
+import core.plugin_instance as plugin_instance
+from core.context import get_context_state
+from core.config import get_active_llm
+
+CommandHandler = Callable[..., Awaitable[str]]
+
+_commands: Dict[str, CommandHandler] = {}
+
+
+def register_command(name: str, handler: CommandHandler) -> None:
+    """Register a backend command handler."""
+    _commands[name] = handler
+    log_debug(f"[command_registry] registered command: {name}")
+
+
+def list_commands() -> list[str]:
+    return list(_commands.keys())
+
+
+def get_handler(name: str) -> CommandHandler | None:
+    return _commands.get(name)
+
+
+async def execute_command(name: str, *args: Any, **kwargs: Any) -> str:
+    handler = get_handler(name)
+    if not handler:
+        raise ValueError(f"Unknown command: {name}")
+    return await handler(*args, **kwargs)
+
+
+async def help_command() -> str:
+    """Generate help text shared across interfaces."""
+    context_status = "active ✅" if get_context_state() else "inactive ❌"
+    llm_mode = await get_active_llm()
+
+    help_text = (
+        "🧞‍♀️ *Rekku – Available Commands*\n\n"
+        "*🧠 Context Mode*\n"
+        f"`/context` – Enable/disable history in forwarded messages, currently *{context_status}*\n\n"
+        "*✏️ /say Command*\n"
+        "`/say` – Select a chat from recent ones\n"
+        "`/say <id> <message>` – Send a message directly to a chat\n\n"
+        "*🧩 Manual Mode*\n"
+        "Reply to a forwarded message with text or content (stickers, photos, audio, files, etc.)\n"
+        "`/cancel` – Cancel a pending send\n\n"
+        "*🧱 User Management*\n"
+        "`/block <user_id>` – Block a user\n"
+        "`/unblock <user_id>` – Unblock a user\n"
+        "`/block_list` – List blocked users\n\n"
+        "*⚙️ LLM Mode*\n"
+        f"`/llm` – Show and select current engine (active: `{llm_mode}`)\n"
+    )
+
+    try:
+        models = plugin_instance.get_supported_models()
+        if models:
+            current_model = plugin_instance.get_current_model() or models[0]
+            help_text += f"`/model` – View or set active model (active: `{current_model}`)\n"
+    except Exception:
+        pass
+
+    help_text += (
+        "\n*📋 Misc*\n"
+        "`/last_chats` – Last active chats\n"
+        "`/purge_map [days]` – Purge old mappings\n"
+        "`/clean_chat_link <chat_id>` – Remove the link between a Telegram chat and ChatGPT.\n"
+        "`/logchat` – Set the current chat as the log chat\n"
+    )
+    return help_text
+
+
+# Register default commands
+register_command("help", help_command)

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -1,0 +1,44 @@
+Commands
+========
+
+Rekku exposes a unified backend for slash commands that can be used from any
+interface (e.g. Telegram, Discord).
+
+General
+-------
+
+* ``/help`` – Display the list of available commands.
+
+Context Mode
+------------
+
+* ``/context`` – Toggle context memory for forwarded messages.
+
+Messaging
+---------
+
+* ``/say`` – Choose a chat from recent ones and send a message.
+* ``/say <id> <message>`` – Send a message directly to a chat.
+* ``/cancel`` – Cancel a pending send started with ``/say``.
+
+User Management
+---------------
+
+* ``/block <user_id>`` – Block a user.
+* ``/unblock <user_id>`` – Unblock a user.
+* ``/block_list`` – List blocked users.
+
+LLM Control
+-----------
+
+* ``/llm`` – Show and select the current LLM engine.
+* ``/model`` – View or set the active model.
+
+Administration
+--------------
+
+* ``/last_chats`` – List recently active chats.
+* ``/purge_map [days]`` – Remove chat mappings older than ``days`` (default 7).
+* ``/logchat`` – Set the current chat as the log chat.
+* ``/manage_chat_id [reset <id>|reset this]`` – Reset stored mapping for a chat.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ getting started.
    installation
    usage
    quickstart
+   commands
    features
    architecture
    event_id_flow

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -6,6 +6,7 @@ import os
 from core.logging_utils import log_debug, log_error, log_info
 from core.transport_layer import universal_send
 from core.core_initializer import core_initializer, register_interface
+from core.command_registry import execute_command
 
 
 class DiscordInterface:
@@ -62,6 +63,10 @@ class DiscordInterface:
         # Actual Discord API call would go here
         # await self.client.get_channel(channel_id).send(text)
         pass
+
+    async def handle_command(self, command_name: str, *args, **kwargs):
+        """Process a slash command via the shared backend."""
+        return await execute_command(command_name, *args, **kwargs)
 
     @staticmethod
     def get_interface_instructions():

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -44,6 +44,7 @@ from core.config import (
     get_log_chat_id_sync,
 )
 from core.config import BOT_TOKEN, BOT_USERNAME, TELEGRAM_TRAINER_ID
+from core.command_registry import execute_command
 
 from core.chat_link_store import (
     ChatLinkStore,
@@ -378,67 +379,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await message.reply_text("⚠️ Error processing message.")
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    from core.context import get_context_state
-    from core.config import get_active_llm
-
     if update.effective_user.id != TELEGRAM_TRAINER_ID:
         return
-
-    context_status = "active ✅" if get_context_state() else "inactive ❌"
-    llm_mode = await get_active_llm()
-
-    help_text = (
-        f"🧞‍♀️ *Rekku – Available Commands*\n\n"
-        "*🧠 Context Mode*\n"
-        f"`/context` – Enable/disable history in forwarded messages, currently *{context_status}*\n\n"
-        "*✏️ /say Command*\n"
-        "`/say` – Select a chat from recent ones\n"
-        "`/say <id> <message>` – Send a message directly to a chat\n\n"
-        "*🧩 Manual Mode*\n"
-        "Reply to a forwarded message with text or content (stickers, photos, audio, files, etc.)\n"
-        "`/cancel` – Cancel a pending send\n\n"
-        "*🧱 User Management*\n"
-        "`/block <user_id>` – Block a user\n"
-        "`/unblock <user_id>` – Unblock a user\n"
-        "`/block_list` – List blocked users\n\n"
-        "*⚙️ LLM Mode*\n"
-        f"`/llm` – Show and select current engine (active: `{llm_mode}`)\n"
-    )
-
-    # Add /model if supported
-    try:
-        models = plugin_instance.get_supported_models()
-        if models:
-            current_model = plugin_instance.get_current_model() or models[0]
-            help_text += f"`/model` – View or set active model (active: `{current_model}`)\n"
-    except Exception:
-        pass
-        current_model = None
-        try:
-            models = plugin_instance.get_supported_models()
-            if models:
-                current_model = plugin_instance.get_current_model() or models[0]
-                help_text += f"`/model` – View or set active model (active: `{current_model}`)\n"
-        except Exception:
-            pass
-            try:
-                current_model = plugin_instance.get_current_model()
-            except Exception:
-                pass
-
-        if current_model:
-            help_text += f"`/model` – View or set active model (active: `{current_model}`)\n"
-        else:
-            help_text += "`/model` – View or set active model\n"
-
-    help_text += (
-        "\n*📋 Misc*\n"
-        "`/last_chats` – Last active chats\n"
-        "`/purge_map [days]` – Purge old mappings\n"
-        "`/clean_chat_link <chat_id>` – Remove the link between a Telegram chat and ChatGPT.\n"
-        "`/logchat` – Set the current chat as the log chat\n"
-    )
-
+    help_text = await execute_command("help")
     await update.message.reply_text(help_text, parse_mode="Markdown")
 
 def escape_markdown(text):

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,10 @@
+import pytest
+from core.command_registry import execute_command, list_commands
+
+
+@pytest.mark.asyncio
+async def test_help_command_registered():
+    assert "help" in list_commands()
+    text = await execute_command("help")
+    assert "Rekku – Available Commands" in text
+    assert "/context" in text


### PR DESCRIPTION
## Summary
- add `core.command_registry` backend for reusable slash commands
- route Telegram and Discord `/help` through shared backend
- add regression test for command registry

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b935200832882ab45e99050e06b