### PR TITLE
feat: track chat link activity

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -686,7 +686,7 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
             "chat_id": getattr(original_message, "chat_id", None),
             "message_id": getattr(original_message, "message_id", None),
             "interface_name": interface_name,
-            "message_thread_id": getattr(original_message, "message_thread_id", None),
+            "thread_id": getattr(original_message, "message_thread_id", None),
         }
 
         try:

--- a/core/auto_response.py
+++ b/core/auto_response.py
@@ -72,7 +72,7 @@ class AutoResponseSystem:
             mock_message.date = datetime.utcnow()
             mock_message.reply_to_message = None
             mock_message.message_thread_id = original_context.get(
-                "message_thread_id"
+                "thread_id"
             )
 
             # Provide chat structure expected by message_queue.enqueue

--- a/core/chat_link_actions.py
+++ b/core/chat_link_actions.py
@@ -40,7 +40,7 @@ class ChatLinkActions:
             "update_chat_name": {
                 "description": "Aggiorna i nomi della chat e del thread usando i dati dell'interfaccia.",
                 "required_fields": ["chat_id"],
-                "optional_fields": ["message_thread_id"],
+                "optional_fields": ["thread_id"],
             }
         }
 
@@ -59,16 +59,16 @@ class ChatLinkActions:
 
         payload = action.get("payload", {})
         chat_id = payload.get("chat_id")
-        message_thread_id = payload.get("message_thread_id")
+        thread_id = payload.get("thread_id")
         try:
             updated = await self.store.update_names_from_resolver(
                 chat_id,
-                message_thread_id,
+                thread_id,
                 bot=bot,
             )
             if updated:
                 log_info(
-                    f"[chat_link_actions] Updated chat link names for chat_id={chat_id}, thread_id={message_thread_id}"
+                    f"[chat_link_actions] Updated chat link names for chat_id={chat_id}, thread_id={thread_id}"
                 )
             else:
                 log_warning("[chat_link_actions] No chat link updated")

--- a/core/chat_link_store.py
+++ b/core/chat_link_store.py
@@ -58,9 +58,9 @@ class ChatLinkStore:
 
     # ------------------------------------------------------------------
     # Helpers
-    def _normalize_thread_id(self, message_thread_id: Optional[int | str]) -> str:
-        """Return ``message_thread_id`` as a non-null string."""
-        return str(message_thread_id) if message_thread_id is not None else "0"
+    def _normalize_thread_id(self, thread_id: Optional[int | str]) -> str:
+        """Return ``thread_id`` as a non-null string."""
+        return str(thread_id) if thread_id is not None else "0"
 
     def _normalize_name(self, value: Optional[str]) -> Optional[str]:
         """Return a cleaned name or ``None`` if not provided."""
@@ -68,6 +68,19 @@ class ChatLinkStore:
             return None
         value = str(value).strip()
         return value if value else None
+
+    async def _update_last_contact(self, chat_id: int | str, thread_id: Optional[int | str]) -> None:
+        """Update the ``last_contact`` timestamp for the given chat/thread."""
+        normalized = self._normalize_thread_id(thread_id)
+        chat_id_str = str(chat_id)
+        conn = await get_conn()
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "UPDATE chatgpt_links SET last_contact = CURRENT_TIMESTAMP WHERE chat_id = %s AND thread_id = %s",
+                (chat_id_str, normalized),
+            )
+            await conn.commit()
+        conn.close()
 
     async def _ensure_table(self) -> None:
         """Create the ``chatgpt_links`` table and new columns if necessary."""
@@ -79,11 +92,12 @@ class ChatLinkStore:
                 """
                 CREATE TABLE IF NOT EXISTS chatgpt_links (
                     chat_id TEXT NOT NULL,
-                    message_thread_id TEXT,
-                    link VARCHAR(2048),
+                    thread_id TEXT,
+                    chatgpt_link VARCHAR(2048),
                     chat_name TEXT,
-                    message_thread_name TEXT,
-                    PRIMARY KEY (chat_id(255), message_thread_id(255))
+                    thread_name TEXT,
+                    last_contact TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (chat_id(255), thread_id(255))
                 )
                 """
             )
@@ -96,10 +110,40 @@ class ChatLinkStore:
                 log_warning(f"[chatlink] chat_name column add failed: {e}")
             try:
                 await cursor.execute(
-                    "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS message_thread_name TEXT"
+                    "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS thread_name TEXT"
                 )
             except Exception as e:  # pragma: no cover
-                log_warning(f"[chatlink] message_thread_name column add failed: {e}")
+                log_warning(f"[chatlink] thread_name column add failed: {e}")
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS last_contact TIMESTAMP"
+                )
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] last_contact column add failed: {e}")
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links CHANGE COLUMN link chatgpt_link VARCHAR(2048)"
+                )
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] chatgpt_link column rename failed: {e}")
+                try:
+                    await cursor.execute(
+                        "ALTER TABLE chatgpt_links ADD COLUMN IF NOT EXISTS chatgpt_link VARCHAR(2048)"
+                    )
+                except Exception as e2:  # pragma: no cover
+                    log_warning(f"[chatlink] chatgpt_link column add failed: {e2}")
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links CHANGE COLUMN message_thread_id thread_id TEXT"
+                )
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] thread_id column rename failed: {e}")
+            try:
+                await cursor.execute(
+                    "ALTER TABLE chatgpt_links CHANGE COLUMN message_thread_name thread_name TEXT"
+                )
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] thread_name column rename failed: {e}")
             await conn.commit()
         conn.close()
         self._table_ensured = True
@@ -109,10 +153,10 @@ class ChatLinkStore:
     async def get_link(
         self,
         chat_id: int | str | None = None,
-        message_thread_id: Optional[int | str] = None,
+        thread_id: Optional[int | str] = None,
         *,
         chat_name: Optional[str] = None,
-        message_thread_name: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> Optional[str]:
         """Return the ChatGPT link for the given identifiers."""
 
@@ -121,36 +165,39 @@ class ChatLinkStore:
         try:
             async with conn.cursor(aiomysql.DictCursor) as cursor:
                 if chat_id is not None:
-                    normalized = self._normalize_thread_id(message_thread_id)
+                    normalized = self._normalize_thread_id(thread_id)
                     chat_id_str = str(chat_id)
                     log_debug(
-                        f"[chatlink] Searching for link: chat_id={chat_id_str}, message_thread_id={normalized}"
+                        f"[chatlink] Searching for link: chat_id={chat_id_str}, thread_id={normalized}"
                     )
                     await cursor.execute(
                         """
-                        SELECT link FROM chatgpt_links
-                        WHERE chat_id = %s AND message_thread_id = %s
+                        SELECT chat_id, thread_id, chatgpt_link, chat_name, thread_name
+                        FROM chatgpt_links
+                        WHERE chat_id = %s AND thread_id = %s
                         """,
                         (chat_id_str, normalized),
                     )
                 elif chat_name is not None:
-                    norm_name = self._normalize_name(message_thread_name)
+                    norm_name = self._normalize_name(thread_name)
                     log_debug(
-                        f"[chatlink] Searching for link: chat_name={chat_name}, message_thread_name={norm_name}"
+                        f"[chatlink] Searching for link: chat_name={chat_name}, thread_name={norm_name}"
                     )
                     if norm_name is None:
                         await cursor.execute(
                             """
-                            SELECT link FROM chatgpt_links
-                            WHERE chat_name = %s AND message_thread_name IS NULL
+                            SELECT chat_id, thread_id, chatgpt_link, chat_name, thread_name
+                            FROM chatgpt_links
+                            WHERE chat_name = %s AND thread_name IS NULL
                             """,
                             (chat_name,),
                         )
                     else:
                         await cursor.execute(
                             """
-                            SELECT link FROM chatgpt_links
-                            WHERE chat_name = %s AND message_thread_name = %s
+                            SELECT chat_id, thread_id, chatgpt_link, chat_name, thread_name
+                            FROM chatgpt_links
+                            WHERE chat_name = %s AND thread_name = %s
                             """,
                             (chat_name, norm_name),
                         )
@@ -160,59 +207,68 @@ class ChatLinkStore:
         finally:
             conn.close()
         if row:
-            return row.get("link")
+            chat_id_val = row.get("chat_id")
+            thread_id_val = row.get("thread_id")
+            await self._update_last_contact(chat_id_val, thread_id_val)
+            if (row.get("chat_name") is None or row.get("thread_name") is None) and self._get_resolver():
+                try:
+                    await self.update_names_from_resolver(chat_id_val, thread_id_val)
+                except Exception as e:  # pragma: no cover
+                    log_warning(f"[chatlink] resolver update failed during get_link: {e}")
+            return row.get("chatgpt_link")
         return None
 
     async def save_link(
         self,
         chat_id: int | str,
-        message_thread_id: Optional[int | str],
-        link: str,
+        thread_id: Optional[int | str],
+        chatgpt_link: str,
         *,
         chat_name: Optional[str] = None,
-        message_thread_name: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> None:
-        """Persist a mapping between a chat (and optional thread) and a link."""
+        """Persist a mapping between a chat (and optional thread) and a ChatGPT link."""
 
         await self._ensure_table()
-        normalized = self._normalize_thread_id(message_thread_id)
+        normalized = self._normalize_thread_id(thread_id)
         chat_id_str = str(chat_id)
         name = self._normalize_name(chat_name)
-        thread_name = self._normalize_name(message_thread_name)
+        thread_name_norm = self._normalize_name(thread_name)
         conn = await get_conn()
         async with conn.cursor() as cursor:
             await cursor.execute(
                 """
                 INSERT INTO chatgpt_links
-                    (chat_id, message_thread_id, link, chat_name, message_thread_name)
-                VALUES (%s, %s, %s, %s, %s)
+                    (chat_id, thread_id, chatgpt_link, chat_name, thread_name, last_contact)
+                VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
                 ON DUPLICATE KEY UPDATE
-                    link=VALUES(link),
+                    chatgpt_link=VALUES(chatgpt_link),
                     chat_name=VALUES(chat_name),
-                    message_thread_name=VALUES(message_thread_name)
+                    thread_name=VALUES(thread_name),
+                    last_contact=CURRENT_TIMESTAMP
                 """,
-                (chat_id_str, normalized, link, name, thread_name),
+                (chat_id_str, normalized, chatgpt_link, name, thread_name_norm),
             )
             await conn.commit()
         conn.close()
         log_debug(
-            f"[chatlink] Saved mapping {chat_id_str}/{normalized} -> {link}"
+            f"[chatlink] Saved mapping {chat_id_str}/{normalized} -> {chatgpt_link}"
         )
 
         # Populate names automatically if resolver available
-        if (chat_name is None or message_thread_name is None) and self._get_resolver():
+        if (chat_name is None or thread_name is None) and self._get_resolver():
             try:
-                await self.update_names_from_resolver(chat_id, message_thread_id)
+                await self.update_names_from_resolver(chat_id, thread_id)
             except Exception as e:  # pragma: no cover - best effort
                 log_warning(f"[chatlink] name resolution failed: {e}")
 
     async def remove(
         self,
         chat_id: int | str | None = None,
-        message_thread_id: Optional[int | str] = None,
+        thread_id: Optional[int | str] = None,
         *,
         chat_name: Optional[str] = None,
-        message_thread_name: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> bool:
         """Remove a mapping. Returns True if a row was deleted."""
 
@@ -221,22 +277,22 @@ class ChatLinkStore:
         try:
             async with conn.cursor() as cursor:
                 if chat_id is not None:
-                    normalized = self._normalize_thread_id(message_thread_id)
+                    normalized = self._normalize_thread_id(thread_id)
                     chat_id_str = str(chat_id)
                     result = await cursor.execute(
                         """
                         DELETE FROM chatgpt_links
-                        WHERE chat_id = %s AND message_thread_id = %s
+                        WHERE chat_id = %s AND thread_id = %s
                         """,
                         (chat_id_str, normalized),
                     )
                 elif chat_name is not None:
-                    norm_name = self._normalize_name(message_thread_name)
+                    norm_name = self._normalize_name(thread_name)
                     if norm_name is None:
                         result = await cursor.execute(
                             """
                             DELETE FROM chatgpt_links
-                            WHERE chat_name = %s AND message_thread_name IS NULL
+                            WHERE chat_name = %s AND thread_name IS NULL
                             """,
                             (chat_name,),
                         )
@@ -244,7 +300,7 @@ class ChatLinkStore:
                         result = await cursor.execute(
                             """
                             DELETE FROM chatgpt_links
-                            WHERE chat_name = %s AND message_thread_name = %s
+                            WHERE chat_name = %s AND thread_name = %s
                             """,
                             (chat_name, norm_name),
                         )
@@ -258,28 +314,28 @@ class ChatLinkStore:
     async def update_names(
         self,
         chat_id: int | str,
-        message_thread_id: Optional[int | str],
+        thread_id: Optional[int | str],
         *,
         chat_name: Optional[str] = None,
-        message_thread_name: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> bool:
         """Update stored chat or thread names. Returns True if a row was updated."""
 
-        if chat_name is None and message_thread_name is None:
+        if chat_name is None and thread_name is None:
             return False
         await self._ensure_table()
-        normalized = self._normalize_thread_id(message_thread_id)
+        normalized = self._normalize_thread_id(thread_id)
         chat_id_str = str(chat_id)
         fields = []
         params: list[Any] = []
         if chat_name is not None:
             fields.append("chat_name = %s")
             params.append(self._normalize_name(chat_name))
-        if message_thread_name is not None:
-            fields.append("message_thread_name = %s")
-            params.append(self._normalize_name(message_thread_name))
+        if thread_name is not None:
+            fields.append("thread_name = %s")
+            params.append(self._normalize_name(thread_name))
         params.extend([chat_id_str, normalized])
-        query = f"UPDATE chatgpt_links SET {', '.join(fields)} WHERE chat_id = %s AND message_thread_id = %s"
+        query = f"UPDATE chatgpt_links SET {', '.join(fields)} WHERE chat_id = %s AND thread_id = %s"
         conn = await get_conn()
         try:
             async with conn.cursor() as cursor:
@@ -292,7 +348,7 @@ class ChatLinkStore:
     async def update_names_from_resolver(
         self,
         chat_id: int | str,
-        message_thread_id: Optional[int | str],
+        thread_id: Optional[int | str],
         bot: Any | None = None,
     ) -> bool:
         """Use the registered resolver to update chat/thread names."""
@@ -302,9 +358,9 @@ class ChatLinkStore:
             return False
         try:
             try:
-                result = await resolver(chat_id, message_thread_id, bot)
+                result = await resolver(chat_id, thread_id, bot)
             except TypeError:  # resolver might not accept bot
-                result = await resolver(chat_id, message_thread_id)
+                result = await resolver(chat_id, thread_id)
         except Exception as e:  # pragma: no cover - best effort
             log_warning(f"[chatlink] resolver execution failed: {e}")
             return False
@@ -312,18 +368,18 @@ class ChatLinkStore:
             return False
         return await self.update_names(
             chat_id,
-            message_thread_id,
+            thread_id,
             chat_name=result.get("chat_name"),
-            message_thread_name=result.get("message_thread_name"),
+            thread_name=result.get("thread_name"),
         )
 
     async def resolve(
         self,
         *,
         chat_id: int | str | None = None,
-        message_thread_id: Optional[int | str] = None,
+        thread_id: Optional[int | str] = None,
         chat_name: Optional[str] = None,
-        message_thread_name: Optional[str] = None,
+        thread_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Resolve a chat link using any combination of identifiers."""
 
@@ -336,19 +392,19 @@ class ChatLinkStore:
                 if chat_id is not None:
                     clauses.append("chat_id = %s")
                     params.append(str(chat_id))
-                if message_thread_id is not None:
-                    clauses.append("message_thread_id = %s")
-                    params.append(self._normalize_thread_id(message_thread_id))
+                if thread_id is not None:
+                    clauses.append("thread_id = %s")
+                    params.append(self._normalize_thread_id(thread_id))
                 if chat_name is not None:
                     clauses.append("chat_name = %s")
                     params.append(chat_name)
-                if message_thread_name is not None:
-                    clauses.append("message_thread_name = %s")
-                    params.append(message_thread_name)
+                if thread_name is not None:
+                    clauses.append("thread_name = %s")
+                    params.append(thread_name)
                 if not clauses:
                     return None
                 query = (
-                    "SELECT chat_id, message_thread_id, link, chat_name, message_thread_name"
+                    "SELECT chat_id, thread_id, chatgpt_link, chat_name, thread_name"
                     f" FROM chatgpt_links WHERE {' AND '.join(clauses)}"
                 )
                 await cursor.execute(query, params)
@@ -360,14 +416,21 @@ class ChatLinkStore:
             return None
         if len(rows) > 1:
             raise ChatLinkMultipleMatches()
-        return rows[0]
+        row = rows[0]
+        await self._update_last_contact(row.get("chat_id"), row.get("thread_id"))
+        if (row.get("chat_name") is None or row.get("thread_name") is None) and self._get_resolver():
+            try:
+                await self.update_names_from_resolver(row.get("chat_id"), row.get("thread_id"))
+            except Exception as e:  # pragma: no cover
+                log_warning(f"[chatlink] resolver update failed during resolve: {e}")
+        return row
 
     # Backwards compatibility
     async def resolve_chat(
-        self, chat_name: str, message_thread_name: Optional[str] = None
+        self, chat_name: str, thread_name: Optional[str] = None
     ) -> Optional[Dict[str, Any]]:
         return await self.resolve(
-            chat_name=chat_name, message_thread_name=message_thread_name
+            chat_name=chat_name, thread_name=thread_name
         )
 
 

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -48,7 +48,7 @@ async def build_json_prompt(message, context_memory) -> dict:
         log_warning(f"[json_prompt] Failed to gather static injections: {e}")
 
     # === 4. Input payload ===
-    message_thread_id = getattr(message, "message_thread_id", None)
+    thread_id = getattr(message, "message_thread_id", None)
     input_payload = {
         "text": text,
         "source": {
@@ -56,7 +56,7 @@ async def build_json_prompt(message, context_memory) -> dict:
             "message_id": message.message_id,
             "username": message.from_user.full_name,
             "usertag": f"@{message.from_user.username}" if message.from_user.username else "(no tag)",
-            "message_thread_id": message_thread_id,
+            "thread_id": thread_id,
         },
         "timestamp": message.date.isoformat(),
         "privacy": "default",

--- a/core/telegram_utils.py
+++ b/core/telegram_utils.py
@@ -126,10 +126,10 @@ async def send_with_thread_fallback(
     chat_id: int | str,
     text: str,
     *,
-    message_thread_id: int | None = None,
+    thread_id: int | None = None,
     reply_to_message_id: int | None = None,
     fallback_chat_id: int | None = None,
-    fallback_message_thread_id: int | None = None,
+    fallback_thread_id: int | None = None,
     fallback_reply_to_message_id: int | None = None,
     **kwargs,
 ) -> None:
@@ -138,7 +138,7 @@ async def send_with_thread_fallback(
     ``message_thread_id`` is the correct Telegram Bot API parameter.  This
     helper mirrors the old ``_send_telegram_message`` logic so that any
     interface can reuse the same behaviour.  It first tries to send with the
-    provided ``message_thread_id`` and falls back to sending without it if the
+    provided ``thread_id`` (mapped to ``message_thread_id``) and falls back to sending without it if the
     thread does not exist.  If ``fallback_chat_id`` is provided it will then try
     sending to that chat using the accompanying fallback parameters.
     """
@@ -156,8 +156,8 @@ async def send_with_thread_fallback(
             return
 
     send_kwargs = {"chat_id": chat_id, "text": text, **kwargs}
-    if message_thread_id is not None:
-        send_kwargs["message_thread_id"] = message_thread_id  # fixed: correct param is message_thread_id
+    if thread_id is not None:
+        send_kwargs["message_thread_id"] = thread_id  # fixed: correct param is message_thread_id
     if reply_to_message_id is not None:
         send_kwargs["reply_to_message_id"] = reply_to_message_id
 
@@ -165,7 +165,7 @@ async def send_with_thread_fallback(
         await bot.send_message(**send_kwargs)
         log_info(
             f"[telegram_utils] Message sent to {chat_id}"
-            f" (thread: {message_thread_id}, reply_message_id: {reply_to_message_id})"
+            f" (thread: {thread_id}, reply_message_id: {reply_to_message_id})"
         )
         return
     except Exception as e:
@@ -186,9 +186,9 @@ async def send_with_thread_fallback(
             except Exception as e2:
                 error_message = str(e2)
 
-        if message_thread_id and "thread not found" in error_message.lower():
+        if thread_id and "thread not found" in error_message.lower():
             log_warning(
-                f"[telegram_utils] Thread {message_thread_id} not found; retrying without thread"
+                f"[telegram_utils] Thread {thread_id} not found; retrying without thread"
             )
             send_kwargs.pop("message_thread_id", None)
             try:
@@ -203,13 +203,13 @@ async def send_with_thread_fallback(
                 )
         else:
             log_error(
-                f"[telegram_utils] Failed to send to {chat_id} (thread {message_thread_id}): {repr(e)}"
+                f"[telegram_utils] Failed to send to {chat_id} (thread {thread_id}): {repr(e)}"
             )
 
     if fallback_chat_id and fallback_chat_id != chat_id:
         fallback_kwargs = {"chat_id": fallback_chat_id, "text": text, **kwargs}
-        if fallback_message_thread_id is not None:
-            fallback_kwargs["message_thread_id"] = fallback_message_thread_id
+        if fallback_thread_id is not None:
+            fallback_kwargs["message_thread_id"] = fallback_thread_id
         if fallback_reply_to_message_id is not None:
             fallback_kwargs["reply_to_message_id"] = fallback_reply_to_message_id
         log_debug(

--- a/core/transport_layer.py
+++ b/core/transport_layer.py
@@ -232,7 +232,7 @@ async def universal_send(interface_send_func, *args, text: str = None, **kwargs)
             message.chat_id = chat_id_value
             message.text = ""
             message.original_text = text
-            message.message_thread_id = kwargs.get('message_thread_id')
+            message.message_thread_id = kwargs.get('thread_id')
             from datetime import datetime
             message.date = datetime.utcnow()
 
@@ -289,7 +289,7 @@ async def universal_send(interface_send_func, *args, text: str = None, **kwargs)
         message.chat_id = kwargs.get('chat_id') or (args[0] if args else None)
         message.text = text
         message.original_text = text
-        message.message_thread_id = kwargs.get('message_thread_id')
+        message.message_thread_id = kwargs.get('thread_id')
         from datetime import datetime
         message.date = datetime.utcnow()
         errors = ["Invalid or missing JSON in LLM response"]
@@ -382,7 +382,7 @@ async def telegram_safe_send(bot, chat_id: int, text: str, chunk_size: int = 400
             message.chat_id = chat_id
             message.text = ""
             message.original_text = text
-            message.message_thread_id = kwargs.get('message_thread_id')
+            message.message_thread_id = kwargs.get('thread_id')
             if 'event_id' in kwargs:
                 message.event_id = kwargs['event_id']
 
@@ -431,7 +431,7 @@ async def telegram_safe_send(bot, chat_id: int, text: str, chunk_size: int = 400
         message.chat_id = chat_id
         message.text = text
         message.original_text = text
-        message.message_thread_id = kwargs.get('message_thread_id')
+        message.message_thread_id = kwargs.get('thread_id')
         if 'event_id' in kwargs:
             message.event_id = kwargs['event_id']
         from datetime import datetime

--- a/docs/chat_links.rst
+++ b/docs/chat_links.rst
@@ -4,20 +4,21 @@ Chat Link Resolution
 Rekku maintains a central **ChatLinkStore** that records the relationship
 between chat identifiers and human‑readable names. Each entry stores:
 
+* ``chatgpt_link`` – ChatGPT conversation identifier
 * ``chat_id`` – numeric identifier for the chat
-* ``message_thread_id`` – optional thread/topic id
+* ``thread_id`` – optional thread/topic id
 * ``chat_name`` – optional chat title
-* ``message_thread_name`` – optional thread/topic title
+* ``thread_name`` – optional thread/topic title
 
 Interfaces can resolve a link by supplying any combination of IDs or names.
-This allows actions to target a conversation using ``chat_id``/``message_thread_id``
-or by specifying ``chat_name``/``message_thread_name``.
+This allows actions to target a conversation using ``chat_id``/``thread_id``
+or by specifying ``chat_name``/``thread_name``.
 
 Updating names
 --------------
 
 The core action ``update_chat_name`` refreshes the stored titles for a chat
-or its thread. At least one of ``chat_name`` or ``message_thread_name`` must
+or its thread. At least one of ``chat_name`` or ``thread_name`` must
 be provided. Interfaces call this after fetching names from their own APIs
 (e.g. Telegram's ``getChat`` and ``getForumTopic``).
 

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -854,22 +854,22 @@ class TelegramInterface:
         """Store the python-telegram-bot ``Bot`` instance."""
         self.bot = bot
         # Register resolver to fetch chat/thread names automatically
-        async def _resolver(chat_id, message_thread_id, bot_instance=None):
+        async def _resolver(chat_id, thread_id, bot_instance=None):
             b = bot_instance or self.bot
             chat_name = None
-            thread_name = None
+            thread_title = None
             try:
                 chat = await b.getChat(chat_id)
                 chat_name = getattr(chat, "title", None) or getattr(chat, "username", None)
             except Exception as e:  # pragma: no cover - network failures
                 log_warning(f"[telegram_interface] chat name lookup failed: {e}")
-            if message_thread_id:
+            if thread_id:
                 try:
-                    topic = await b.getForumTopic(chat_id, message_thread_id)
-                    thread_name = getattr(topic, "name", None) or getattr(topic, "title", None)
+                    topic = await b.getForumTopic(chat_id, int(thread_id))
+                    thread_title = getattr(topic, "name", None) or getattr(topic, "title", None)
                 except Exception as e:  # pragma: no cover
                     log_warning(f"[telegram_interface] thread name lookup failed: {e}")
-            return {"chat_name": chat_name, "message_thread_name": thread_name}
+            return {"chat_name": chat_name, "thread_name": thread_title}
 
         chat_link_store.set_name_resolver(_resolver)
 
@@ -887,8 +887,8 @@ class TelegramInterface:
                 "optional_fields": [
                     "target",
                     "chat_name",
-                    "message_thread_id",
-                    "message_thread_name",
+                    "thread_id",
+                    "thread_name",
                 ],
                 "description": "Send a text message via Telegram",
             },
@@ -897,8 +897,8 @@ class TelegramInterface:
                 "optional_fields": [
                     "target",
                     "chat_name",
-                    "message_thread_id",
-                    "message_thread_name",
+                    "thread_id",
+                    "thread_name",
                 ],
                 "description": "Send a voice message via Telegram",
             },
@@ -924,16 +924,16 @@ class TelegramInterface:
                         "description": "Alternative to target for specifying the chat by name",
                         "optional": True,
                     },
-                    "message_thread_id": {
+                    "thread_id": {
                         "type": "integer",
                         "example": 456,
                         "description": "Optional thread ID for group chats",
                         "optional": True,
                     },
-                    "message_thread_name": {
+                    "thread_name": {
                         "type": "string",
                         "example": "Generale",
-                        "description": "Alternative to message_thread_id to specify the thread by name",
+                        "description": "Alternative to thread_id to specify the thread by name",
                         "optional": True,
                     },
                     "reply_to_message_id": {
@@ -961,7 +961,7 @@ class TelegramInterface:
                         "description": "Alternative to target for specifying the chat by name",
                         "optional": True,
                     },
-                    "message_thread_id": {
+                    "thread_id": {
                         "type": "integer",
                         "example": 456,
                         "description": "Optional thread ID for group chats",
@@ -996,21 +996,21 @@ class TelegramInterface:
             if target is not None:
                 if isinstance(target, dict):
                     chat_id = target.get("chat_id")
-                    message_thread_id = target.get("message_thread_id")
+                    thread_id = target.get("thread_id")
                     if chat_id is not None and not isinstance(chat_id, (int, str)):
                         errors.append("payload.target.chat_id must be an int or string")
-                    if message_thread_id is not None and not isinstance(message_thread_id, int):
-                        errors.append("payload.target.message_thread_id must be an int")
+                    if thread_id is not None and not isinstance(thread_id, int):
+                        errors.append("payload.target.thread_id must be an int")
                 elif not isinstance(target, (int, str)):
                     errors.append("payload.target must be an int, string or dict")
 
-        message_thread_id = payload.get("message_thread_id")
-        if message_thread_id is not None and not isinstance(message_thread_id, int):
-            errors.append("payload.message_thread_id must be an int")
+        thread_id = payload.get("thread_id")
+        if thread_id is not None and not isinstance(thread_id, int):
+            errors.append("payload.thread_id must be an int")
 
-        thread_name = payload.get("message_thread_name")
+        thread_name = payload.get("thread_name")
         if thread_name is not None and not isinstance(thread_name, str):
-            errors.append("payload.message_thread_name must be a string")
+            errors.append("payload.thread_name must be a string")
 
         return errors
 
@@ -1021,22 +1021,22 @@ class TelegramInterface:
         ----------
         payload: dict
             Must contain at least ``text`` and ``target``. Optionally may include
-            ``message_thread_id``.
+            ``thread_id``.
         original_message: object | None
             The triggering message; used for reply fallback handling.
 
         ``message_thread_id`` is the correct Telegram parameter for replies in
-        topics and replaces the legacy ``thread_id`` name.
+        topics; internally we use ``thread_id``.
         """
 
         text = payload.get("text", "")
         target = payload.get("target")
         chat_name = payload.get("chat_name")
-        message_thread_id = payload.get("message_thread_id")
-        thread_name = payload.get("message_thread_name")
+        thread_id = payload.get("thread_id")
+        thread_name = payload.get("thread_name")
 
         log_debug(
-            f"[telegram_interface] Sending to target={target} chat_name={chat_name} thread_id={message_thread_id} thread_name={thread_name}"
+            f"[telegram_interface] Sending to target={target} chat_name={chat_name} thread_id={thread_id} thread_name={thread_name}"
         )
 
         if not text or (target is None and chat_name is None):
@@ -1047,8 +1047,8 @@ class TelegramInterface:
 
         if isinstance(target, dict):
             chat_id = target.get("chat_id")
-            message_thread_id = target.get("message_thread_id", message_thread_id)
-            thread_name = target.get("message_thread_name", thread_name)
+            thread_id = target.get("thread_id", thread_id)
+            thread_name = target.get("thread_name", thread_name)
         elif target is not None:
             if isinstance(target, str) and not target.lstrip("-").isdigit():
                 chat_name = target
@@ -1058,13 +1058,13 @@ class TelegramInterface:
                 except Exception:
                     chat_name = target
 
-        if chat_id is None or (message_thread_id is None and thread_name is not None):
+        if chat_id is None or (thread_id is None and thread_name is not None):
             try:
                 row = await chat_link_store.resolve(
                     chat_id=chat_id,
-                    message_thread_id=message_thread_id,
+                    thread_id=thread_id,
                     chat_name=chat_name,
-                    message_thread_name=thread_name,
+                    thread_name=thread_name,
                 )
             except ChatLinkMultipleMatches:
                 await corrector(
@@ -1087,7 +1087,7 @@ class TelegramInterface:
                 )
                 return
             chat_id = row.get("chat_id", chat_id)
-            message_thread_id = row.get("message_thread_id", message_thread_id)
+            thread_id = row.get("thread_id", thread_id)
 
         try:
             target_for_comparison = int(chat_id)
@@ -1095,7 +1095,7 @@ class TelegramInterface:
             log_warning(f"[telegram_interface] Invalid chat identifier: {chat_id}")
             return
 
-        await chat_link_store.update_names_from_resolver(chat_id, message_thread_id, bot=self.bot)
+        await chat_link_store.update_names_from_resolver(chat_id, thread_id, bot=self.bot)
 
         chat_id_int = target_for_comparison
 
@@ -1110,7 +1110,7 @@ class TelegramInterface:
             log_debug(f"[telegram_interface] reply_to_message_id: {reply_message_id}")
 
         fallback_chat_id = None
-        fallback_message_thread_id = None
+        fallback_thread_id = None
         fallback_reply_to = None
         if (
             original_message
@@ -1118,7 +1118,7 @@ class TelegramInterface:
             and chat_id_int != getattr(original_message, "chat_id")
         ):
             fallback_chat_id = original_message.chat_id
-            fallback_message_thread_id = getattr(original_message, "message_thread_id", None)
+            fallback_thread_id = getattr(original_message, "message_thread_id", None)
             if hasattr(original_message, "message_id"):
                 fallback_reply_to = original_message.message_id
 
@@ -1127,10 +1127,10 @@ class TelegramInterface:
             chat_id_int,
             text,
             parse_mode="Markdown",
-            message_thread_id=message_thread_id,  # fixed: correct param is message_thread_id
+            message_thread_id=thread_id,  # fixed: correct param is message_thread_id
             reply_to_message_id=reply_message_id,
             fallback_chat_id=fallback_chat_id,
-            fallback_message_thread_id=fallback_message_thread_id,
+            fallback_message_thread_id=fallback_thread_id,
             fallback_reply_to_message_id=fallback_reply_to,
         )
 
@@ -1150,8 +1150,8 @@ class TelegramInterface:
         audio = payload.get("audio")
         target = payload.get("target")
         chat_name = payload.get("chat_name")
-        message_thread_id = payload.get("message_thread_id")
-        thread_name = payload.get("message_thread_name")
+        thread_id = payload.get("thread_id")
+        thread_name = payload.get("thread_name")
 
         if not audio or (target is None and chat_name is None):
             log_warning("[telegram_interface] Missing audio or destination, aborting")
@@ -1161,8 +1161,8 @@ class TelegramInterface:
 
         if isinstance(target, dict):
             chat_id = target.get("chat_id")
-            message_thread_id = target.get("message_thread_id", message_thread_id)
-            thread_name = target.get("message_thread_name", thread_name)
+            thread_id = target.get("thread_id", thread_id)
+            thread_name = target.get("thread_name", thread_name)
         elif target is not None:
             if isinstance(target, str) and not target.lstrip("-").isdigit():
                 chat_name = target
@@ -1172,13 +1172,13 @@ class TelegramInterface:
                 except Exception:
                     chat_name = target
 
-        if chat_id is None or (message_thread_id is None and thread_name is not None):
+        if chat_id is None or (thread_id is None and thread_name is not None):
             try:
                 row = await chat_link_store.resolve(
                     chat_id=chat_id,
-                    message_thread_id=message_thread_id,
+                    thread_id=thread_id,
                     chat_name=chat_name,
-                    message_thread_name=thread_name,
+                    thread_name=thread_name,
                 )
             except ChatLinkMultipleMatches:
                 await corrector(
@@ -1201,7 +1201,7 @@ class TelegramInterface:
                 )
                 return
             chat_id = row.get("chat_id", chat_id)
-            message_thread_id = row.get("message_thread_id", message_thread_id)
+            thread_id = row.get("thread_id", thread_id)
 
         try:
             target_for_comparison = int(chat_id)
@@ -1219,8 +1219,8 @@ class TelegramInterface:
             reply_message_id = original_message.message_id
 
         send_kwargs = {"chat_id": target_for_comparison}
-        if message_thread_id is not None:
-            send_kwargs["message_thread_id"] = message_thread_id
+        if thread_id is not None:
+            send_kwargs["message_thread_id"] = thread_id
         if reply_message_id is not None:
             send_kwargs["reply_to_message_id"] = reply_message_id
 
@@ -1231,7 +1231,7 @@ class TelegramInterface:
             return
         except Exception as e:
             error_message = str(e)
-            if message_thread_id and "thread not found" in error_message.lower():
+            if thread_id and "thread not found" in error_message.lower():
                 send_kwargs.pop("message_thread_id", None)
                 converted = await self._convert_to_voice(audio)
                 with open(converted, "rb") as f:
@@ -1257,7 +1257,7 @@ class TelegramInterface:
         return (
             "TELEGRAM INTERFACE INSTRUCTIONS:\n"
             "- Use chat_id or chat_name for targets (chat_id can be negative for groups/channels).\n"
-            "- Include message_thread_id or message_thread_name when replying in topics; omit otherwise.\n"
+            "- Include thread_id or thread_name when replying in topics; omit otherwise.\n"
             "- Keep messages under 4096 characters.\n"
             "- Markdown is supported and preferred.\n"
             "- Replying to a message in the same chat will automatically use that message as the reply target.\n"

--- a/llm_engines/selenium_chatgpt.py
+++ b/llm_engines/selenium_chatgpt.py
@@ -1388,8 +1388,8 @@ class SeleniumChatGPTPlugin(AIPluginBase):
 
             log_debug("[selenium][STEP] ensuring ChatGPT is accessible")
 
-            message_thread_id = getattr(message, "message_thread_id", None)
-            chat_id = await chat_link_store.get_link(message.chat_id, message_thread_id)
+            thread_id = getattr(message, "message_thread_id", None)
+            chat_id = await chat_link_store.get_link(message.chat_id, thread_id)
             prompt_text = json.dumps(prompt, ensure_ascii=False)
             if isinstance(prompt, dict) and "system_message" in prompt:
                 prompt_text = f"```json\n{prompt_text}\n```"
@@ -1398,9 +1398,9 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                 if path and go_to_chat_by_path_with_retries(driver, path):
                     chat_id = _extract_chat_id(driver.current_url)
                     if chat_id:
-                        await chat_link_store.save_link(message.chat_id, message_thread_id, chat_id)
+                        await chat_link_store.save_link(message.chat_id, thread_id, chat_id)
                         _safe_notify(
-                            f"\u26a0\ufe0f Couldn't find ChatGPT conversation for Telegram chat_id={message.chat_id}, message_thread_id={message_thread_id}.\n"
+                            f"\u26a0\ufe0f Couldn't find ChatGPT conversation for Telegram chat_id={message.chat_id}, thread_id={thread_id}.\n"
                             f"A new ChatGPT chat has been created: {chat_id}"
                         )
                 else:
@@ -1419,13 +1419,13 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                 except Exception as e:
                     log_warning(f"[selenium] Existing chat {chat_id} no longer accessible: {e}")
                     log_info(f"[selenium] Creating new chat to replace inaccessible chat {chat_id}")
-                    await chat_link_store.remove(message.chat_id, message_thread_id)
+                    await chat_link_store.remove(message.chat_id, thread_id)
                     recent_chats.clear_chat_path(message.chat_id)
                     _open_new_chat(driver)
                     chat_id = None
 
             log_debug(f"[selenium][DEBUG] Chat ID from store: {chat_id}")
-            log_debug(f"[selenium][DEBUG] Telegram chat_id: {message.chat_id}, message_thread_id: {message_thread_id}")
+            log_debug(f"[selenium][DEBUG] Telegram chat_id: {message.chat_id}, thread_id: {thread_id}")
 
             if not chat_id:
                 try:
@@ -1453,10 +1453,10 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                         log_debug(f"[selenium][DEBUG] New chat created, extracted ID: {new_chat_id}")
                         log_debug(f"[selenium][DEBUG] Current URL: {driver.current_url}")
                         if new_chat_id:
-                            await chat_link_store.save_link(message.chat_id, message_thread_id, new_chat_id)
-                            log_debug(f"[selenium][DEBUG] Saved link: {message.chat_id}/{message_thread_id} -> {new_chat_id}")
+                            await chat_link_store.save_link(message.chat_id, thread_id, new_chat_id)
+                            log_debug(f"[selenium][DEBUG] Saved link: {message.chat_id}/{thread_id} -> {new_chat_id}")
                             _safe_notify(
-                                f"\u26a0\ufe0f Couldn't find ChatGPT conversation for Telegram chat_id={message.chat_id}, message_thread_id={message_thread_id}.\n"
+                                f"\u26a0\ufe0f Couldn't find ChatGPT conversation for Telegram chat_id={message.chat_id}, thread_id={thread_id}.\n"
                                 f"A new ChatGPT chat has been created: {new_chat_id}"
                             )
                         else:
@@ -1470,7 +1470,7 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                     response_text = process_prompt_in_chat(driver, None, prompt_text, "")
                     new_chat_id = _extract_chat_id(driver.current_url)
                     if new_chat_id:
-                        await chat_link_store.save_link(message.chat_id, message_thread_id, new_chat_id)
+                        await chat_link_store.save_link(message.chat_id, thread_id, new_chat_id)
                         log_debug(
                             f"[selenium][SUCCESS] New chat created for full conversation. Chat ID: {new_chat_id}"
                         )
@@ -1484,7 +1484,7 @@ class SeleniumChatGPTPlugin(AIPluginBase):
                     chat_id=message.chat_id,
                     text=response_text,
                     reply_to_message_id=getattr(message, "message_id", None),
-                    message_thread_id=message_thread_id,
+                    message_thread_id=thread_id,
                     event_id=getattr(message, "event_id", None),
                 )
                 log_debug(

--- a/plugins/event_plugin.py
+++ b/plugins/event_plugin.py
@@ -587,7 +587,7 @@ For recurring events, you can use:
             chat=SimpleNamespace(
                 id="SYSTEM_SCHEDULER", type="private", title="System Scheduler"
             ),
-            message_thread_id=None,
+            thread_id=None,
         )
 
     async def _execute_action_silently(self, action: dict, event_id: int):
@@ -617,7 +617,7 @@ For recurring events, you can use:
         try:
             text = payload.get("text", "")
             target_chat_id = payload.get("target")
-            message_thread_id = payload.get("message_thread_id")
+            thread_id = payload.get("thread_id")
 
             if not text or not target_chat_id:
                 log_error(
@@ -631,7 +631,7 @@ For recurring events, you can use:
 
             # Get the appropriate transport layer directly
             await self._send_via_transport_layer(
-                target_chat_id, text, message_thread_id, event_id
+                target_chat_id, text, thread_id, event_id
             )
 
         except Exception as e:
@@ -643,7 +643,7 @@ For recurring events, you can use:
         self,
         chat_id: int,
         text: str,
-        message_thread_id: int = None,
+        thread_id: int = None,
         event_id: int = None,
     ):
         """Send message directly via transport layer, bypassing interfaces."""
@@ -652,12 +652,12 @@ For recurring events, you can use:
             if chat_id < 0:
                 # Negative IDs are typically Telegram groups/channels
                 await self._send_via_telegram_transport(
-                    chat_id, text, message_thread_id, event_id
+                    chat_id, text, thread_id, event_id
                 )
             else:
                 # Positive IDs could be Telegram private chats or other platforms
                 await self._send_via_telegram_transport(
-                    chat_id, text, message_thread_id, event_id
+                    chat_id, text, thread_id, event_id
                 )
 
         except Exception as e:
@@ -669,7 +669,7 @@ For recurring events, you can use:
         self,
         chat_id: int,
         text: str,
-        message_thread_id: int = None,
+        thread_id: int = None,
         event_id: int = None,
     ):
         """Send message directly via Telegram transport layer."""
@@ -690,7 +690,7 @@ For recurring events, you can use:
                 bot,
                 chat_id,
                 text,
-                message_thread_id=message_thread_id,  # fixed: correct param is message_thread_id
+                message_thread_id=thread_id,  # fixed: correct param is message_thread_id
                 parse_mode="Markdown",
             )
 
@@ -704,7 +704,7 @@ For recurring events, you can use:
             )
             # Fallback: use the bot instance directly if available
             await self._fallback_send_telegram(
-                chat_id, text, message_thread_id, event_id
+                chat_id, text, thread_id, event_id
             )
         except Exception as e:
             log_error(
@@ -715,7 +715,7 @@ For recurring events, you can use:
         self,
         chat_id: int,
         text: str,
-        message_thread_id: int = None,
+        thread_id: int = None,
         event_id: int = None,
     ):
         """Fallback method to send via Telegram bot directly."""
@@ -735,7 +735,7 @@ For recurring events, you can use:
                     bot,
                     chat_id,
                     text,
-                    message_thread_id=message_thread_id,  # fixed: correct param is message_thread_id
+                    message_thread_id=thread_id,  # fixed: correct param is message_thread_id
                     parse_mode="Markdown",
                 )
                 log_info(
@@ -860,7 +860,7 @@ For recurring events, you can use:
         target_chat_id = action.get("payload", {}).get(
             "target", SCHEDULED_EVENTS_CHAT_ID
         )
-        message_thread_id = action.get("payload", {}).get("message_thread_id")
+        thread_id = action.get("payload", {}).get("thread_id")
 
         # Extract lateness info
         is_late = event_info.get("is_late", False) if event_info else False
@@ -893,11 +893,11 @@ For recurring events, you can use:
             ),
             # Store the real target info for final message routing
             _scheduled_target_chat_id=target_chat_id,
-            _scheduled_message_thread_id=message_thread_id,
+            _scheduled_thread_id=thread_id,
             # Store lateness info
             _is_late=is_late,
             _minutes_late=minutes_late,
-            # Add message_thread_id if present (for topic support)
+            # Add thread_id if present (for topic support)
             message_thread_id=None,  # Scheduled events don't use threads in their own chat
         )
 
@@ -1051,7 +1051,7 @@ Weekly recurring reminder:
                 """Handle LLM responses and delegate to action parser."""
                 text = kwargs.get("text", "")
                 chat_id = kwargs.get("chat_id")
-                message_thread_id = kwargs.get("message_thread_id")
+                thread_id = kwargs.get("thread_id")
 
                 log_debug(f"[event_plugin] LLM responded with: {text[:100]}...")
 
@@ -1078,7 +1078,7 @@ Weekly recurring reminder:
                                 ),
                                 "message_thread_id": response_action.get(
                                     "payload", {}
-                                ).get("message_thread_id", message_thread_id),
+                                ).get("thread_id", thread_id),
                             },
                         )()
 

--- a/plugins/selenium_elevenlabs.py
+++ b/plugins/selenium_elevenlabs.py
@@ -229,7 +229,7 @@ class SeleniumElevenLabsPlugin:
             return
         payload = {"audio": file_path, "target": {"chat_id": chat_id}}
         if thread_id is not None:
-            payload["target"]["message_thread_id"] = thread_id
+            payload["target"]["thread_id"] = thread_id
         try:
             await iface.send_audio(payload)
         except Exception as e:

--- a/plugins/terminal.py
+++ b/plugins/terminal.py
@@ -130,7 +130,7 @@ class TerminalPlugin(AIPluginBase):
                 "chat_id": getattr(message, "chat_id", None),
                 "message_id": getattr(message, "message_id", None),
                 "interface_name": "telegram_bot",
-                "message_thread_id": getattr(message, "message_thread_id", None),
+                "thread_id": getattr(message, "message_thread_id", None),
             }
 
             await request_llm_delivery(
@@ -232,8 +232,8 @@ class TerminalPlugin(AIPluginBase):
                 'chat_id': getattr(original_message, 'chat_id', context.get('chat_id')),
                 'message_id': getattr(original_message, 'message_id', context.get('message_id')),
                 'interface_name': interface_name,
-                'message_thread_id': getattr(
-                    original_message, 'message_thread_id', context.get('message_thread_id')
+                'thread_id': getattr(
+                    original_message, 'message_thread_id', context.get('thread_id')
                 ),
             }
             if delivery_context['chat_id'] is not None:

--- a/tests/test_event_id_filtering.py
+++ b/tests/test_event_id_filtering.py
@@ -19,7 +19,7 @@ async def test_event_id_filtered_from_helpers():
         "reply_to_message_id": 123,
         "event_id": 456,
         "parse_mode": "HTML",
-        "message_thread_id": 789,
+        "thread_id": 789,
     }
 
     mock_bot = AsyncMock()

--- a/tests/test_telegram_validation.py
+++ b/tests/test_telegram_validation.py
@@ -16,7 +16,7 @@ def _action(payload):
 
 
 def _payload(target):
-    payload = {"text": "Test message", "target": target, "message_thread_id": 2}
+    payload = {"text": "Test message", "target": target, "thread_id": 2}
     return payload
 
 


### PR DESCRIPTION
## Summary
- rename thread fields to `thread_id`/`thread_name`
- track `last_contact` for chat link mappings
- update Telegram helpers and interfaces for new identifiers
- persist `thread_name` by resolving names on link lookup
- rename `link` column to `chatgpt_link`

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68ae73038d48832894438d690e460b27