### PR TITLE
docs: list current interfaces, plugins, and LLM engines

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -9,6 +9,31 @@ core system.
 
 .. _Read the Docs: https://rekku.readthedocs.io
 
+Available Interfaces
+--------------------
+
+The repository currently includes the following interfaces:
+
+* ``cli`` – local command-line interface (no configuration).
+* ``discord_interface`` – Discord bot connector.  Set ``DISCORD_BOT_TOKEN`` in ``.env``.
+* ``reddit_interface`` – asynchronous Reddit client.  Requires ``REDDIT_CLIENT_ID``, ``REDDIT_CLIENT_SECRET``, ``REDDIT_USERNAME``, ``REDDIT_PASSWORD`` and ``REDDIT_USER_AGENT``.
+* ``telegram_bot`` – Telegram bot interface.  Provide ``BOTFATHER_TOKEN`` (or ``TELEGRAM_TOKEN``) and trainer ID ``TELEGRAM_TRAINER_ID``.
+* ``telethon_userbot`` – userbot using Telethon.  Set ``API_ID``, ``API_HASH`` and ``SESSION``.
+* ``webui`` – FastAPI-based web interface.  ``WEBUI_HOST`` and ``WEBUI_PORT`` control binding.
+* ``x_interface`` – experimental X (Twitter) integration.  Configure ``X_USERNAME`` for timeline features.
+
+Discord Bot Setup
+-----------------
+
+Follow these steps to connect Rekku to Discord:
+
+1. Create an application in the `Discord Developer Portal <https://discord.com/developers/applications>`_.
+2. Under **Bot**, add a bot and copy its token.
+3. Enable the **Message Content Intent** and any other privileged intents your bot needs.
+4. In **OAuth2 → URL Generator**, select the ``bot`` scope and invite the bot to your server with the desired permissions.
+5. Store the token in an ``.env`` file or environment variable named ``DISCORD_BOT_TOKEN``.
+6. Start Rekku (for example, ``python main.py``); the ``discord_interface`` module loads automatically and uses the token to connect.
+
 1. **Create the module**
    Place a new ``*.py`` file under the ``interface/`` directory.  The core now
    imports all modules in ``interface/``, ``plugins/`` and ``llm_engines/``

--- a/docs/llm_engines.rst
+++ b/docs/llm_engines.rst
@@ -3,10 +3,18 @@ LLM Engines
 
 The Rekku Freedom Project can operate with multiple language model backends. Use the ``/llm`` command in chat to switch engines at runtime.
 
+Available Engines
+-----------------
+
+* ``manual`` – forward prompts to a human trainer (no configuration).
+* ``openai_chatgpt`` – access OpenAI's ChatGPT API.  Set ``OPENAI_API_KEY`` and optional ``CHATGPT_MODEL``.
+* ``google_cli`` – use Google's Gemini via the ``gemini`` command-line client.  Requires ``GEMINI_API_KEY`` and the ``gemini`` tool.
+* ``selenium_chatgpt`` – drive a browser session of ChatGPT.  Use ``REKKU_SELENIUM_HEADLESS`` and ``CHATGPT_MODEL``; ``WEBVIEW_HOST``/``WEBVIEW_PORT`` expose the desktop.
+
 Selenium ChatGPT
 ----------------
 
-The ``selenium_chatgpt`` plugin drives a real ChatGPT session using a browser. A manual login is required the first time.
+The ``selenium_chatgpt`` plugin drives a real ChatGPT session using a browser. A manual login is required the first time.  Set ``CHATGPT_MODEL`` to pick a model and ``REKKU_SELENIUM_HEADLESS=0`` to view the browser. ``WEBVIEW_HOST`` and ``WEBVIEW_PORT`` determine the remote desktop address.
 
 Steps:
 
@@ -21,7 +29,13 @@ Manual
 
 The ``manual`` engine simply forwards prompts to a human trainer. It can be useful for debugging or during development.
 
-ChatGPT API
------------
+OpenAI ChatGPT
+--------------
 
-A simpler API-based engine is also provided but has not been fully tested. Contributions are welcome.
+The ``openai_chatgpt`` engine calls OpenAI's ChatGPT API using the ``openai`` Python package.
+Provide an API key via ``OPENAI_API_KEY`` and optionally set ``CHATGPT_MODEL``.
+
+Google CLI
+----------
+
+The ``google_cli`` engine sends prompts to the ``gemini`` command-line tool in order to use Google's Gemini models.  Set ``GEMINI_API_KEY`` and ensure ``gemini`` is installed.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -15,6 +15,18 @@ or storage.
 
 .. _Read the Docs: https://rekku.readthedocs.io
 
+Available Action Plugins
+------------------------
+
+* ``bio_manager`` – manage persistent user biographies. Uses database settings ``DB_HOST``, ``DB_USER``, ``DB_PASS`` and ``DB_NAME``.
+* ``event`` – schedule and deliver reminders. Requires ``DB_HOST``, ``DB_PORT``, ``DB_USER``, ``DB_PASS``, ``DB_NAME`` and optional ``CORRECTOR_RETRIES``.
+* ``message_plugin`` – send text across registered interfaces (no configuration).
+* ``reddit_plugin`` – submit posts and comments to Reddit. Requires ``REDDIT_CLIENT_ID``, ``REDDIT_CLIENT_SECRET``, ``REDDIT_USERNAME``, ``REDDIT_PASSWORD`` and ``REDDIT_USER_AGENT``.
+* ``selenium_elevenlabs`` – generate speech audio with ElevenLabs. Set ``ELEVENLABS_EMAIL`` and ``ELEVENLABS_PASSWORD`` (``REKKU_SELENIUM_HEADLESS`` controls headless mode).
+* ``terminal`` – run shell commands or interactive sessions. Uses ``TELEGRAM_TRAINER_ID`` to authorize access.
+* ``time_plugin`` – inject current time and location (no configuration).
+* ``weather_plugin`` – provide weather info as static context. Optional ``WEATHER_FETCH_TIME`` sets refresh interval.
+
 Terminal
 --------
 
@@ -22,11 +34,17 @@ Terminal
 sent to the bot are executed in a background ``/bin/bash`` process and the
 output is returned.
 
+.. note::
+   Access is limited to the trainer ID configured via ``TELEGRAM_TRAINER_ID``.
+
 Event
 -----
 
 The ``event`` plugin stores scheduled reminders in a MariaDB table. A background
 scheduler checks for due events and sends them back to Rekku when the time comes.
+
+.. note::
+   Requires database credentials (``DB_HOST``, ``DB_PORT``, ``DB_USER``, ``DB_PASS``, ``DB_NAME``).
 
 All Python modules under ``plugins/``, ``llm_engines/`` and ``interface/`` are
 imported recursively on startup. Plugin files no longer need a special naming
@@ -38,7 +56,8 @@ Reddit Interface
 
 ``reddit_interface`` allows Rekku to read posts, handle direct messages and
 manage subreddit subscriptions. Credentials for Reddit must be provided in the
-``.env`` file.
+``.env`` file (``REDDIT_CLIENT_ID``, ``REDDIT_CLIENT_SECRET``, ``REDDIT_USERNAME``,
+``REDDIT_PASSWORD`` and ``REDDIT_USER_AGENT``).
 
 Reddit Actions
 --------------


### PR DESCRIPTION
## Summary
- document environment variables for all interfaces
- outline configuration for action plugins such as event, reddit, and ElevenLabs
- note API key setup for OpenAI, Google CLI, and Selenium ChatGPT engines
- add step-by-step instructions for configuring and connecting a Discord bot

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-telegram-bot; Tunnel connection failed: 403 Forbidden)*
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b454b012948328854834ddfcc9f371