### PR TITLE
Handle Discord replies lacking text

### DIFF
--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -128,8 +128,11 @@ async def handle_incoming_message(bot, message, context_memory_or_prompt):
         log_debug(f"[plugin_instance] Received message: {message_text}")
         log_debug(f"[plugin_instance] Context memory: {context_memory_or_prompt}")
         user_id = message.from_user.id if message.from_user else "unknown"
+        interface_name = (
+            bot.get_interface_id() if hasattr(bot, "get_interface_id") else bot.__class__.__name__
+        )
         log_debug(
-            f"[plugin] Incoming for {plugin.__class__.__name__}: chat_id={message.chat_id}, user_id={user_id}, text={message_text!r}"
+            f"[plugin] Incoming for {plugin.__class__.__name__}: chat_id={message.chat_id}, user_id={user_id}, text={message_text!r} via {interface_name}"
         )
         if isinstance(context_memory_or_prompt, str):
             try:
@@ -138,9 +141,9 @@ async def handle_incoming_message(bot, message, context_memory_or_prompt):
                 prompt = json.loads(context_memory_or_prompt)
             except Exception as e:
                 log_warning(f"[plugin_instance] Failed to parse direct prompt: {e}")
-                prompt = await build_json_prompt(message, {})
+                prompt = await build_json_prompt(message, {}, interface_name)
         else:
-            prompt = await build_json_prompt(message, context_memory_or_prompt)
+            prompt = await build_json_prompt(message, context_memory_or_prompt, interface_name)
 
     prompt = sanitize_for_json(prompt)
     log_debug("🌐 JSON PROMPT built for the plugin:")

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -65,15 +65,20 @@ async def build_json_prompt(message, context_memory) -> dict:
 
     if message.reply_to_message:
         reply = message.reply_to_message
-        reply_text = reply.text or getattr(reply, "caption", None)
+        reply_text = getattr(reply, "text", None) or getattr(reply, "caption", None)
         if not reply_text:
             reply_text = "[Non-text content]"
+        reply_date = getattr(reply, "date", None)
+        reply_timestamp = reply_date.isoformat() if reply_date else ""
+        reply_from = getattr(reply, "from_user", None)
+        reply_full_name = getattr(reply_from, "full_name", "Unknown") if reply_from else "Unknown"
+        reply_username = getattr(reply_from, "username", None) if reply_from else None
         input_payload["reply_message_id"] = {
             "text": reply_text,
-            "timestamp": reply.date.isoformat(),
+            "timestamp": reply_timestamp,
             "from": {
-                "username": reply.from_user.full_name,
-                "usertag": f"@{reply.from_user.username}" if reply.from_user.username else "(no tag)",
+                "username": reply_full_name,
+                "usertag": f"@{reply_username}" if reply_username else "(no tag)",
             },
         }
 

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -7,15 +7,17 @@ from core.json_utils import dumps as json_dumps
 import aiomysql
 
 
-async def build_json_prompt(message, context_memory) -> dict:
+async def build_json_prompt(message, context_memory, interface_name: str | None = None) -> dict:
     """Build the JSON prompt expected by plugins.
 
     Parameters
     ----------
     message : telegram.Message
-        Incoming message object from telegram bot.
+        Incoming message object from an interface.
     context_memory : dict[int, deque]
         Dictionary storing last messages per chat.
+    interface_name : str | None
+        Identifier of the interface that delivered the message.
     """
 
     chat_id = getattr(message, "chat_id", None)
@@ -82,7 +84,11 @@ async def build_json_prompt(message, context_memory) -> dict:
             },
         }
 
-    input_section = {"type": "message", "payload": input_payload}
+    input_section = {
+        "type": "message",
+        "interface": interface_name,
+        "payload": input_payload,
+    }
 
     # Debug output for both sections
     log_debug("[json_prompt] context = " + json_dumps(context_section))

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -18,8 +18,8 @@ async def build_json_prompt(message, context_memory) -> dict:
         Dictionary storing last messages per chat.
     """
 
-    chat_id = message.chat_id
-    text = message.text or ""
+    chat_id = getattr(message, "chat_id", None)
+    text = getattr(message, "text", "") or ""
 
     # === 1. Context messages ===
     messages = list(context_memory.get(chat_id, []))[-10:]
@@ -63,8 +63,8 @@ async def build_json_prompt(message, context_memory) -> dict:
         "scope": "local",
     }
 
-    if message.reply_to_message:
-        reply = message.reply_to_message
+    reply = getattr(message, "reply_to_message", None)
+    if reply:
         reply_text = getattr(reply, "text", None) or getattr(reply, "caption", None)
         if not reply_text:
             reply_text = "[Non-text content]"

--- a/core/telegram_utils.py
+++ b/core/telegram_utils.py
@@ -170,6 +170,11 @@ async def send_with_thread_fallback(
         return message
     except Exception as e:
         error_message = str(e)
+        if "chat not found" in error_message.lower():
+            log_error(
+                f"[telegram_utils] Failed to send to {chat_id} (thread {message_thread_id}): {repr(e)}"
+            )
+            raise
 
         # Retry without parse_mode if Markdown/HTML entities are malformed
         if "can't parse entities" in error_message.lower() and send_kwargs.get("parse_mode"):
@@ -201,10 +206,12 @@ async def send_with_thread_fallback(
                 log_error(
                     f"[telegram_utils] Fallback without thread failed: {no_thread_error}"
                 )
+                raise
         else:
             log_error(
                 f"[telegram_utils] Failed to send to {chat_id} (thread {message_thread_id}): {repr(e)}"
             )
+            raise
 
     if fallback_chat_id and fallback_chat_id != chat_id:
         fallback_kwargs = {"chat_id": fallback_chat_id, "text": text, **kwargs}
@@ -225,4 +232,5 @@ async def send_with_thread_fallback(
             log_error(
                 f"[telegram_utils] Final fallback failed: {fallback_error}"
             )
+            raise
     return None

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -212,6 +212,9 @@ class DiscordInterface:
                 if replied is not None:
                     reply_to = SimpleNamespace(
                         message_id=getattr(replied, "id", None),
+                        text=getattr(replied, "content", None),
+                        caption=None,
+                        date=getattr(replied, "created_at", None),
                         from_user=SimpleNamespace(
                             id=getattr(replied.author, "id", None),
                             username=getattr(replied.author, "name", None),

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -1010,10 +1010,6 @@ class TelegramInterface:
                     "type": "error",
                     "step": step,
                     "message": details,
-                    "your_reply": json.dumps(
-                        {"actions": [{"type": "message_telegram_bot", "payload": payload}]},
-                        ensure_ascii=False,
-                    ),
                     "full_json_instructions": full_json,
                     "error_retry_policy": ERROR_RETRY_POLICY,
                 }
@@ -1029,6 +1025,7 @@ class TelegramInterface:
             msg.text = payload_json
             from datetime import datetime
             msg.date = datetime.utcnow()
+            msg.from_user = SimpleNamespace(id=TELEGRAM_TRAINER_ID)
             llm = plugin_instance.get_plugin()
             if llm and hasattr(llm, "handle_incoming_message"):
                 await llm.handle_incoming_message(self.bot, msg, payload_json)

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -9,19 +9,22 @@ def test_build_json_prompt_reply_without_text(monkeypatch):
     async def dummy_gather(message, ctx):
         return {}
 
-    monkeypatch.setattr('core.action_parser.gather_static_injections', dummy_gather)
+    monkeypatch.setattr("core.action_parser.gather_static_injections", dummy_gather)
 
     message = SimpleNamespace(
         chat_id=1,
-        text='hello',
+        text="hello",
         message_id=1,
-        from_user=SimpleNamespace(full_name='user', username='user'),
+        from_user=SimpleNamespace(full_name="user", username="user"),
         date=datetime.utcnow(),
         reply_to_message=SimpleNamespace(
             message_id=2,
-            from_user=SimpleNamespace(full_name='bot', username='bot'),
+            from_user=SimpleNamespace(full_name="bot", username="bot"),
         ),
     )
 
-    result = asyncio.run(build_json_prompt(message, {}))
-    assert result['input']['payload']['reply_message_id']['text'] == '[Non-text content]'
+    result = asyncio.run(build_json_prompt(message, {}, interface_name="discord_bot"))
+    assert result["input"]["interface"] == "discord_bot"
+    assert (
+        result["input"]["payload"]["reply_message_id"]["text"] == "[Non-text content]"
+    )

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -1,0 +1,27 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+
+from core.prompt_engine import build_json_prompt
+
+
+def test_build_json_prompt_reply_without_text(monkeypatch):
+    async def dummy_gather(message, ctx):
+        return {}
+
+    monkeypatch.setattr('core.action_parser.gather_static_injections', dummy_gather)
+
+    message = SimpleNamespace(
+        chat_id=1,
+        text='hello',
+        message_id=1,
+        from_user=SimpleNamespace(full_name='user', username='user'),
+        date=datetime.utcnow(),
+        reply_to_message=SimpleNamespace(
+            message_id=2,
+            from_user=SimpleNamespace(full_name='bot', username='bot'),
+        ),
+    )
+
+    result = asyncio.run(build_json_prompt(message, {}))
+    assert result['input']['payload']['reply_message_id']['text'] == '[Non-text content]'

--- a/tests/test_telegram_error_handling.py
+++ b/tests/test_telegram_error_handling.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+import json
+import pytest
+
+# Ensure required environment variables
+os.environ.setdefault("TELEGRAM_TRAINER_ID", "123456")
+
+# Stub minimal telegram modules before importing the interface
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram.Bot = object
+telegram.error = types.ModuleType("error")
+telegram.error.TelegramError = Exception
+telegram.error.RetryAfter = Exception
+telegram.ext = types.ModuleType("ext")
+telegram.ext.ApplicationBuilder = object
+telegram.ext.MessageHandler = object
+telegram.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=None)
+telegram.ext.CommandHandler = object
+telegram.ext.filters = types.SimpleNamespace()
+sys.modules["telegram"] = telegram
+sys.modules["telegram.error"] = telegram.error
+sys.modules["telegram.ext"] = telegram.ext
+
+import core.plugin_instance as plugin_instance
+from interface.telegram_bot import TelegramInterface
+
+class DummyBot:
+    async def send_message(self, *args, **kwargs):
+        pass
+
+class DummyPlugin:
+    def __init__(self):
+        self.calls = []
+
+    async def handle_incoming_message(self, bot, message, payload_json):
+        self.calls.append((bot, message, payload_json))
+
+@pytest.mark.asyncio
+async def test_emit_system_error_avoids_retry():
+    orig_plugin = plugin_instance.plugin
+    plugin = DummyPlugin()
+    plugin_instance.plugin = plugin
+    interface = TelegramInterface(DummyBot())
+    payload = {"text": "hi", "target": "999"}
+    await interface._emit_system_error("retry_exhausted", "failed", payload)
+    assert len(plugin.calls) == 1
+    payload_json = plugin.calls[0][2]
+    data = json.loads(payload_json)
+    assert "your_reply" not in data["system_message"]
+    assert hasattr(plugin.calls[0][1], "from_user")
+    plugin_instance.plugin = orig_plugin


### PR DESCRIPTION
## Summary
- avoid AttributeError in `build_json_prompt` when reply lacks text or timestamp
- include `text` and `date` for reply metadata in `discord_interface`
- add regression test for replies without text

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68b53b0267e083288604ba958547004d