### PR TITLE
Report actual interface name

### DIFF
--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -105,7 +105,11 @@ async def enqueue(bot, message, context_memory, priority: bool = False) -> None:
     await recent_chats.track_chat(chat_id, meta)
 
     thread_id = getattr(message, "message_thread_id", None)
-    interface = bot.__class__.__name__ if bot else None
+    interface = (
+        bot.get_interface_id()
+        if bot and hasattr(bot, "get_interface_id")
+        else bot.__class__.__name__ if bot else None
+    )
 
     item = {
         "bot": bot,

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -34,6 +34,7 @@ class DiscordInterface:
             intents = discord.Intents.default()
             intents.message_content = True
             self.client = discord.Client(intents=intents)
+            setattr(self.client, "get_interface_id", self.get_interface_id)
 
             @self.client.event
             async def on_ready():

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -835,6 +835,7 @@ class TelegramInterface:
     def __init__(self, bot: Bot):
         """Store the python-telegram-bot ``Bot`` instance."""
         self.bot = bot
+        setattr(self.bot, "get_interface_id", self.get_interface_id)
         # Register resolver to fetch chat/thread names automatically
         async def _resolver(chat_id, message_thread_id, bot_instance=None):
             b = bot_instance or self.bot


### PR DESCRIPTION
## Summary
- derive interface name from each bot's `get_interface_id`
- attach `get_interface_id` to Discord and Telegram bot instances

## Testing
- `python -m venv venv && source venv/bin/activate && pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement python-telegram-bot)*
- `./run_tests.sh` *(failed: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2fda1388328990266947235a8d9