### PR TITLE
docs: expand extension development guides

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -17,6 +17,7 @@ Rekku can operate with different language models:
 
 * ``manual`` – forwards prompts to the trainer for manual replies.
 * ``openai_chatgpt`` – uses the OpenAI API.
+* ``google_cli`` – queries Google's Gemini models via the ``gemini`` command‑line tool.
 * ``selenium_chatgpt`` – drives a real ChatGPT session via Selenium.
 
 Switch between engines at runtime with ``/llm``.
@@ -34,12 +35,27 @@ Rekku stores chat and thread identifiers in a central resolver. Interfaces can
 target conversations using either numeric IDs or human‑readable names, and the
 ``update_chat_name`` action refreshes the stored titles when they change.
 
+Multi-Interface Support
+-----------------------
+
+Communication is handled by pluggable interfaces. Connectors are available for
+Telegram, Discord, Reddit, a local CLI, a web UI and an experimental X (Twitter)
+client. Each interface registers its actions independently and can be enabled or
+removed without affecting the others.
+
 Plugin Architecture
 -------------------
 
-LLM engines and other actions are provided through plugins. Available action
-plugins include ``terminal`` for shell access and ``event`` for scheduled
-reminders.
+LLM engines and other actions are provided through plugins. Built-in examples
+include:
+
+* ``terminal`` – run shell commands from chat.
+* ``event`` – schedule reminders stored in the database.
+* ``message_plugin`` – send text to any registered interface.
+* ``reddit_plugin`` – create posts and comments on Reddit.
+* ``time_plugin`` – inject current date, time and location.
+* ``weather_plugin`` – add the local weather as static context.
+* ``selenium_elevenlabs`` – generate speech audio via ElevenLabs.
 
 Context Memory
 --------------

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -51,12 +51,12 @@ Follow these steps to connect Rekku to Discord:
    snippets.
 
 4. **Register the interface**
-   When the interface starts, use ``register_interface`` to store the instance
-   and ``core_initializer.register_interface`` to mark it active.
+   When the interface starts, use ``register_interface`` to store the instance.
+   This automatically marks it active and exposes its actions.
 
 .. code-block:: python
 
-   from core.core_initializer import core_initializer, register_interface
+   from core.core_initializer import register_interface
 
    class MyInterface:
        @staticmethod
@@ -75,9 +75,23 @@ Follow these steps to connect Rekku to Discord:
 
        async def start(self):
            register_interface("myiface", self)
-           core_initializer.register_interface("myiface")
 
    INTERFACE_CLASS = MyInterface
 
 With these pieces in place the core initializer will automatically collect the
 interface's actions and make them available to the LLM.
+
+Interface API
+-------------
+
+Interfaces typically expose the following methods:
+
+* ``get_interface_id()`` – **required**; return a unique identifier.
+* ``get_supported_actions()`` – **required**; declare actions the interface can
+  perform.
+* ``get_prompt_instructions(action_type)`` – optional extra guidance for the
+  LLM.
+* ``start()`` / ``stop()`` – asynchronous setup and teardown logic where
+  ``register_interface`` is usually called.
+* Any action handlers declared in ``get_supported_actions`` are invoked when the
+  LLM requests them.

--- a/docs/llm_engines.rst
+++ b/docs/llm_engines.rst
@@ -39,3 +39,30 @@ Google CLI
 ----------
 
 The ``google_cli`` engine sends prompts to the ``gemini`` command-line tool in order to use Google's Gemini models.  Set ``GEMINI_API_KEY`` and ensure ``gemini`` is installed.
+
+Developing LLM Engines
+----------------------
+
+Custom engines live in ``llm_engines/`` and subclass ``AIPluginBase``.  A
+minimal engine implements ``generate_response`` and exposes a module-level
+``PLUGIN_CLASS``:
+
+.. code-block:: python
+
+   from core.ai_plugin_base import AIPluginBase
+
+   class MyEngine(AIPluginBase):
+       async def generate_response(self, messages):
+           return "Hello from MyEngine"
+
+   PLUGIN_CLASS = MyEngine
+
+Useful hooks inherited from ``AIPluginBase``:
+
+* ``generate_response(messages)`` – **required**; return LLM output.
+* ``get_supported_models()`` – list available model IDs.
+* ``get_rate_limit()`` – tuple of rate limit settings.
+* ``get_supported_action_types()`` and ``handle_custom_action()`` – declare and
+  handle engine-specific actions.
+* ``get_supported_actions()`` and ``get_prompt_instructions()`` – supply schema
+  data or prompt hints for custom actions.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,12 +9,15 @@ Usage Overview
 
 Rekku operates as a modular AI persona with multiple LLM backends. You can
 switch engines on the fly using the ``/llm`` command in your preferred chat
-platform. Supported modes include ``manual``, ``openai_chatgpt`` and
-``selenium_chatgpt``.
+platform. Supported modes include ``manual``, ``openai_chatgpt``, ``google_cli``
+and ``selenium_chatgpt``.
 
 Message forwarding is automatic when Rekku is mentioned or receives a private
 message. The ``event`` plugin stores reminders in the configured database and
-delivers them when due.
+delivers them when due. Additional plugins extend behaviour: the
+``message_plugin`` sends text to any registered interface, ``time_plugin`` and
+``weather_plugin`` inject temporal and environmental context, ``reddit_plugin``
+creates posts and comments, and ``selenium_elevenlabs`` generates speech audio.
 
 Contextual memory can be toggled with ``/context``. When enabled, the last ten
 messages are injected into the prompt sent to the active LLM.


### PR DESCRIPTION
## Summary
- clarify plugin extension points and provide a minimal plugin template
- add LLM engine guide with template and available hooks
- describe interface startup and list common interface methods

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68be41404eb0832896e1e110969521a1